### PR TITLE
feat: add map filter matching functionality in jinja2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+* Adding map filter based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.map). [#8](https://github.com/gunjam/govjucks/pull/8) @gunjam
+
 ## v0.1.0 (First release)
 
 This is the first release since forking nunjucks, a lot of work has been done

--- a/bench/filters/map.mjs
+++ b/bench/filters/map.mjs
@@ -1,0 +1,39 @@
+import { summary, bench, run, group } from 'mitata';
+import { Environment } from '../../src/environment.js';
+import gFilters from '../../src/filters.js';
+import runtime from '../../src/runtime.js';
+
+const env = new Environment();
+const gMap = gFilters.map.bind({ env });
+
+const attributeKwargs = runtime.makeKeywordArgs({
+  attribute: 'a'
+});
+
+const attributeDefaultKwargs = runtime.makeKeywordArgs({
+  attribute: 'a',
+  default: 'b'
+});
+
+// Not available in nunjucks
+summary(() => {
+  group('map', () => {
+    bench('govjucks', () => {
+      gMap(['A', 'B', 'C', 'D', 'E'], 'lower');
+    });
+  });
+
+  group('map - attribute', () => {
+    bench('govjucks', () => {
+      gMap([{ a: 'A' }, { a: 'B' }, { a: 'C' }, { a: 'D' }, { a: 'E' }], attributeKwargs);
+    });
+  });
+
+  group('map - attribute default', () => {
+    bench('govjucks', () => {
+      gMap([{ a: 'A' }, { a: 'B' }, { a: undefined }, { a: 'D' }, { a: undefined }], attributeDefaultKwargs);
+    });
+  });
+});
+
+run();

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1421,6 +1421,40 @@ Convert string to all lower case:
 foobar
 ```
 
+### map
+
+Returns a new list after applying a filter to every item in the input list:
+
+**Input**
+
+```jinja
+{{ ["A", "B", "C"] | map("lower") | join("") }}
+{{ ["LONGSTRING", "VERYLONGSTRING"] | map("truncate", 2, true, "_") | join("") }}
+```
+
+**Output**
+
+```jinja
+abc
+LO_VE_
+```
+
+Or, given a list of objects, return a list of attribute values:
+
+**Input**
+
+```jinja
+{{ [{msg: "Hello"}, {msg: "World"}] | map(attribute="msg") | join(" ") }}
+{{ [{msg: "Hello"}, {}] | map(attribute="msg", default="missing") | join(" ") }}
+```
+
+**Output**
+
+```jinja
+Hello World
+Hello missing
+```
+
 ### nl2br
 
 Replace new lines with `<br />` HTML elements:

--- a/src/filters.js
+++ b/src/filters.js
@@ -989,6 +989,43 @@ const intFilter = r.makeMacro(
 
 module.exports.int = intFilter;
 
+module.exports.map = function map (...args) {
+  const kwargs = args[args.length - 1];
+
+  if (r.isKeywordArgs(kwargs)) {
+    const value = args[0];
+    const len = value.length;
+    const arr = new Array(len);
+    const attribute = kwargs.attribute;
+    const defaultValue = kwargs.default;
+
+    if (!attribute) {
+      throw new lib.TemplateError('missing "attribute" keyword argument');
+    }
+    for (let i = 0; i < len; i++) {
+      arr[i] = value[i]?.[attribute] ?? defaultValue;
+    }
+    return arr;
+  }
+
+  const filterName = args[1];
+
+  if (!filterName) {
+    throw new lib.TemplateError('missing filter name');
+  }
+
+  const value = args[0];
+  const len = value.length;
+  const arr = new Array(len);
+  const filter = this.env.getFilter(filterName).bind(this);
+  const filterArgs = args.slice(2);
+  for (let i = 0; i < len; i++) {
+    arr[i] = filter(value[i], ...filterArgs);
+  }
+
+  return arr;
+};
+
 // Aliases
 module.exports.d = module.exports.default;
 module.exports.e = module.exports.escape;

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -600,6 +600,60 @@ describe('filter', () => {
     finish(done);
   });
 
+  describe('map', () => {
+    it('filter', (t, done) => {
+      equal('{{ titles | map("lower") | join(", ") }}', {
+        titles: [
+          'MY PAGE',
+          'NEXT PAGE',
+        ]
+      }, 'my page, next page');
+
+      equal('{{ titles | map("truncate", 2, true, "_") | join(", ")  }}', {
+        titles: [
+          'LOOOOOOOOOOOONG, LOOOOOOOOOOOONG',
+          'LOOOOOOOOOOOONG, LOOOOOOOOOOOONG',
+        ]
+      }, 'LO_, LO_');
+
+      assert.throws(() => render('{{ titles | map() }}', { titles: ['A'] }), {
+        message: /Template render error: missing filter name/
+      });
+
+      finish(done);
+    });
+
+    it('attribute', (t, done) => {
+      equal('{{ users | map(attribute="username") | join(", ") }}', {
+        users: [
+          { username: 'John' },
+          { username: 'Jim' },
+          { username: undefined }
+        ]
+      }, 'John, Jim, undefined');
+
+      equal('{{ users | map(attribute="username", default="Anonymous") | join(", ") }}', {
+        users: [
+          { username: 'John' },
+          { username: 'Jim' },
+          {},
+        ]
+      }, 'John, Jim, Anonymous');
+
+      assert.throws(() => render('{{ users | map(default="Anonymous") | join(", ") }}', {
+        users: [
+          { username: 'John' },
+          { username: 'Jim' },
+          {},
+        ]
+      }), {
+        message: /Template render error: missing "attribute" keyword argument/
+      });
+
+      finish(done);
+    });
+  });
+
   it('nl2br', (t, done) => {
     equal('{{ null | nl2br }}', '');
     equal('{{ undefined | nl2br }}', '');


### PR DESCRIPTION
## Summary

Proposed change:

Add map filter to match the Jinja2 [implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.map).

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
