### PR TITLE
feat: support passing in test to selectattr and rejectattr filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Adding map filter based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.map). [#8](https://github.com/gunjam/govjucks/pull/8) @gunjam
+* Added support for passing tests into the selectattr and rejectattr filters. This brings it inline with the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.selectattr). [#9](https://github.com/gunjam/govjucks/pull/9) @gunjam
 
 ## v0.1.0 (First release)
 

--- a/bench/filters/selectattr.mjs
+++ b/bench/filters/selectattr.mjs
@@ -7,24 +7,24 @@ import nFilters from 'nunjucks/src/filters.js';
 const gEnv = new GEnvironment();
 const nEnv = new NEnvironment();
 
-const gRejectAttr = gFilters.rejectattr.bind({ env: gEnv });
-const nRejectAttr = nFilters.rejectattr.bind({ env: nEnv });
+const gSelectAttr = gFilters.selectattr.bind({ env: gEnv });
+const nSelectAttr = nFilters.selectattr.bind({ env: nEnv });
 
 summary(() => {
-  group('rejectattr', () => {
+  group('selectattr', () => {
     bench('govjucks', () => {
-      gRejectAttr([{ a: 1 }, { b: 1 }, { a: 1 }, { b: 1 }, { a: 1 }, { b: 1 }], 'b');
+      gSelectAttr([{ a: 1 }, { b: 1 }, { a: 1 }, { b: 1 }, { a: 1 }, { b: 1 }], 'b');
     });
 
     bench('nunjucks', () => {
-      nRejectAttr([{ a: 1 }, { b: 1 }, { a: 1 }, { b: 1 }, { a: 1 }, { b: 1 }], 'b');
+      nSelectAttr([{ a: 1 }, { b: 1 }, { a: 1 }, { b: 1 }, { a: 1 }, { b: 1 }], 'b');
     });
   });
 
   // Not supported in nunjucks
-  group('rejectattr - with test', () => {
+  group('selectattr - with test', () => {
     bench('govjucks', () => {
-      gRejectAttr([{ a: 1 }, { b: 1 }, { b: 2 }, { b: 1 }, { a: 1 }, { b: 1 }], 'b', 'odd');
+      gSelectAttr([{ a: 1 }, { b: 1 }, { b: 2 }, { b: 1 }, { a: 1 }, { b: 1 }], 'b', 'odd');
     });
   });
 });

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1513,7 +1513,7 @@ If no test is specified, each object will be evaluated as a boolean.
 0
 ```
 
-### rejectattr (only the single-argument form)
+### rejectattr
 
 Filter a sequence of objects by applying a test to the specified attribute
 of each object, and rejecting the objects with the test succeeding.
@@ -1525,13 +1525,17 @@ If no test is specified, the attribute’s value will be evaluated as a boolean.
 **Input**
 
 ```jinja
-{% set foods = [{tasty: true}, {tasty: false}, {tasty: true}]%}
+{% set foods = [{tasty: true}, {tasty: false}, {tasty: true}] %}
 {{ foods | rejectattr("tasty") | length }}
+
+{% set people = [{age: 30}, {age: 21}, {age: 23}] %}
+{{ people | rejectattr("age", "odd") | length }}
 ```
 
 **Output**
 
 ```jinja
+1
 1
 ```
 
@@ -1722,7 +1726,7 @@ If no test is specified, each object will be evaluated as a boolean.
 12345
 ```
 
-### selectattr (only the single-argument form)
+### selectattr
 
 Filter a sequence of objects by applying a test to the specified attribute
 of each object, and only selecting the objects with the test succeeding.
@@ -1734,13 +1738,17 @@ If no test is specified, the attribute’s value will be evaluated as a boolean.
 **Input**
 
 ```jinja
-{% set foods = [{tasty: true}, {tasty: false}, {tasty: true}]%}
+{% set foods = [{tasty: true}, {tasty: false}, {tasty: true}] %}
 {{ foods | selectattr("tasty") | length }}
+
+{% set people = [{age: 30}, {age: 21}, {age: 23}] %}
+{{ people | selectattr("age", "odd") | length }}
 ```
 
 **Output**
 
 ```jinja
+2
 2
 ```
 

--- a/src/filters.js
+++ b/src/filters.js
@@ -441,13 +441,18 @@ module.exports.reject = getSelectOrReject(false);
  * boolean.
  * @param {Array<object>} arr
  * @param {string} attr
+ * @param {string} testName
+ * @param {any} secondArg
  * @returns {Array<object>}
  */
-function rejectattr (arr, attr) {
-  return arr.filter((item) => !item[attr]);
-}
+module.exports.rejectattr = function rejectattr (arr, attr, testName, secondArg) {
+  if (!testName) {
+    return arr.filter((v) => !v[attr]);
+  }
 
-module.exports.rejectattr = rejectattr;
+  const test = this.env.getTest(testName).bind(this);
+  return arr.filter((item) => !test(item[attr], secondArg));
+};
 
 module.exports.select = getSelectOrReject(true);
 
@@ -461,13 +466,18 @@ module.exports.select = getSelectOrReject(true);
  * boolean.
  * @param {Array<object>} arr
  * @param {string} attr
+ * @param {string} testName
+ * @param {any} secondArg
  * @returns {Array<object>}
  */
-function selectattr (arr, attr) {
-  return arr.filter((item) => !!item[attr]);
-}
+module.exports.selectattr = function selectattr (arr, attr, testName, secondArg) {
+  if (!testName) {
+    return arr.filter((v) => v[attr]);
+  }
 
-module.exports.selectattr = selectattr;
+  const test = this.env.getTest(testName).bind(this);
+  return arr.filter((item) => test(item[attr], secondArg));
+};
 
 /**
  * Replace one item with another. The first item is the item to be

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -711,6 +711,18 @@ describe('filter', () => {
     equal('{{ foods | rejectattr("tasty") | length }}', {
       foods
     }, '1');
+
+    const people = [{
+      age: 30
+    }, {
+      age: 21
+    }, {
+      age: 23
+    }];
+    equal('{{ people | rejectattr("age", "odd") | length }}', {
+      people
+    }, '1');
+
     finish(done);
   });
 
@@ -741,6 +753,18 @@ describe('filter', () => {
     equal('{{ foods | selectattr("tasty") | length }}', {
       foods
     }, '2');
+
+    const people = [{
+      age: 30
+    }, {
+      age: 21
+    }, {
+      age: 23
+    }];
+    equal('{{ people | selectattr("age", "odd") | length }}', {
+      people
+    }, '2');
+
     finish(done);
   });
 


### PR DESCRIPTION
Brings the filters inline with the jinja2 equivalents

## Summary

Added support for passing tests into the selectattr and rejectattr filters. This brings it more inline with the [Jinja2 implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.selectattr).

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
