### PR TITLE
feat: add filesizeformat filter inline with Jinja2 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Adding map filter based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.map). [#8](https://github.com/gunjam/govjucks/pull/8) @gunjam
 * Added support for passing tests into the selectattr and rejectattr filters. This brings it inline with the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.selectattr). [#9](https://github.com/gunjam/govjucks/pull/9) @gunjam
+* Adding a file size format filter which matches the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.filesizeformat). [#10](https://github.com/gunjam/govjucks/pull/10) @gunjam
 
 ## v0.1.0 (First release)
 

--- a/bench/filters/filesizeformat.mjs
+++ b/bench/filters/filesizeformat.mjs
@@ -1,0 +1,30 @@
+import { group, summary, bench, run } from 'mitata';
+import gFilters from '../../src/filters.js';
+
+const filesizeformat = gFilters.filesizeformat;
+
+summary(() => {
+  group('govjucks', () => {
+    bench('filesizeformat - under 1 kB', () => {
+      filesizeformat(900);
+    });
+
+    bench('filesizeformat - under 1 KiB', () => {
+      filesizeformat(1_020, true);
+    });
+
+    bench('filesizeformat - 1.5 MB', () => {
+      filesizeformat(1_500_000);
+    });
+
+    bench('filesizeformat - 1.5 MiB', () => {
+      filesizeformat(1_572_864, true);
+    });
+
+    bench('filesizeformat - 1.5 MB string', () => {
+      filesizeformat('1500000');
+    });
+  });
+});
+
+run();

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1103,6 +1103,27 @@ Marks return value as markup string
 &lt;html&gt;
 ```
 
+### filesizeformat
+
+Format the input value into a ‘human-readable’ file size, defaults to decimal
+sizes (kB, MB) passing true as a paramter will use binary (KiB, MiB). 
+
+**Input**
+
+```jinja
+{{ 100 | filesizeformat }}
+{{ 1024 | filesizeformat(true) }}
+{{ "1500000" | filesizeformat }}
+```
+
+**Output**
+
+```jinja
+100 B
+1.0 KiB
+1.5 MB
+```
+
 ### first
 
 Get the first item in an array or the first letter if it's a string:

--- a/src/filters.js
+++ b/src/filters.js
@@ -1036,6 +1036,41 @@ module.exports.map = function map (...args) {
   return arr;
 };
 
+/**
+ * Format a file size into a human readable format. Uses a decimal format by
+ * default, but passing true in the binary parameter will use a binary format.
+ * @param {number} value
+ * @param {boolean} [binary=false]
+ */
+function filesizeformat (value, binary = false) {
+  let size = Math.abs(value);
+  let thresh;
+  let units;
+
+  if (binary) {
+    thresh = 1_024;
+    units = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB', 'RiB', 'QiB'];
+  } else {
+    thresh = 1_000;
+    units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB', 'RB', 'QB'];
+  }
+
+  if (size < thresh) {
+    return `${value} B`;
+  }
+
+  let unitIndex = 0;
+
+  while (size >= thresh && unitIndex < units.length - 1) {
+    size /= thresh;
+    unitIndex++;
+  }
+
+  return `${size.toFixed(1)} ${units[unitIndex]}`;
+}
+
+module.exports.filesizeformat = filesizeformat;
+
 // Aliases
 module.exports.d = module.exports.default;
 module.exports.e = module.exports.escape;

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -229,6 +229,40 @@ describe('filter', () => {
     finish(done);
   });
 
+  it('filesizeformat', (t, done) => {
+    // Decimal
+    equal('{{ size | filesizeformat }}', { size: 1 }, '1 B');
+    equal('{{ size | filesizeformat }}', { size: 999 }, '999 B');
+    equal('{{ size | filesizeformat }}', { size: 1_000 }, '1.0 kB');
+    equal('{{ size | filesizeformat }}', { size: 1_000 * 1_000 }, '1.0 MB');
+    equal('{{ size | filesizeformat }}', { size: 1_000 * 1_000 * 1_000 }, '1.0 GB');
+    equal('{{ size | filesizeformat }}', { size: 1_000 * 1_000 * 1_000 * 1_000 }, '1.0 TB');
+    equal('{{ size | filesizeformat }}', { size: 1_000 * 1_000 * 1_000 * 1_000 * 1_000 }, '1.0 PB');
+    equal('{{ size | filesizeformat }}', { size: 1_000 * 1_000 * 1_000 * 1_000 * 1_000 * 1_000 }, '1.0 EB');
+    equal('{{ size | filesizeformat }}', { size: 1_000 * 1_000 * 1_000 * 1_000 * 1_000 * 1_000 * 1_000 }, '1.0 ZB');
+    equal('{{ size | filesizeformat }}', { size: 1_000 * 1_000 * 1_000 * 1_000 * 1_000 * 1_000 * 1_000 * 1_000 }, '1.0 YB');
+    equal('{{ size | filesizeformat }}', { size: 1_500 * 1_000 * 1_000 }, '1.5 GB');
+
+    // Binary
+    equal('{{ size | filesizeformat(true) }}', { size: 1 }, '1 B');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_023 }, '1023 B');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_024 }, '1.0 KiB');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_024 * 1_024 }, '1.0 MiB');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_024 * 1_024 * 1_024 }, '1.0 GiB');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_024 * 1_024 * 1_024 * 1_024 }, '1.0 TiB');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_024 * 1_024 * 1_024 * 1_024 * 1_024 }, '1.0 PiB');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_024 * 1_024 * 1_024 * 1_024 * 1_024 * 1_024 }, '1.0 EiB');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_024 * 1_024 * 1_024 * 1_024 * 1_024 * 1_024 * 1_024 }, '1.0 ZiB');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_024 * 1_024 * 1_024 * 1_024 * 1_024 * 1_024 * 1_024 * 1_024 }, '1.0 YiB');
+    equal('{{ size | filesizeformat(true) }}', { size: 1_536 * 1_024 * 1_024 }, '1.5 GiB');
+
+    // String
+    equal('{{ size | filesizeformat }}', { size: '1000' }, '1.0 kB');
+    equal('{{ size | filesizeformat(true) }}', { size: '1024' }, '1.0 KiB');
+
+    finish(done);
+  });
+
   it('first', (t, done) => {
     equal('{{ [1,2,3] | first }}', '1');
     finish(done);


### PR DESCRIPTION
## Summary

Proposed change:

Adding a file size format filter which matches the [Jinja2 implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.filesizeformat).

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
