### PR TITLE
feat: add printf style format filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Adding map filter based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.map). [#8](https://github.com/gunjam/govjucks/pull/8) @gunjam
 * Added support for passing tests into the selectattr and rejectattr filters. This brings it inline with the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.selectattr). [#9](https://github.com/gunjam/govjucks/pull/9) @gunjam
 * Adding a file size format filter which matches the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.filesizeformat). [#10](https://github.com/gunjam/govjucks/pull/10) @gunjam
+* Adding a printf style format filter, like [Jinja](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.format).
+  Maps directly to the [Node.js format util](https://nodejs.org/docs/latest-v24.x/api/util.html#utilformatformat-args),
+  so may not behave exactly like the python equivalent. [#11](https://github.com/gunjam/govjucks/pull/11) @gunjam
 
 ## v0.1.0 (First release)
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1167,6 +1167,25 @@ This default can be overridden by using the first parameter.
 
 Enforce HTML escaping. This will probably double escape variables.
 
+### format
+
+Apply the given values to a printf-style format string, maps directly to the
+[Node.js format util](https://nodejs.org/docs/latest-v24.x/api/util.html#utilformatformat-args).
+
+**Input**
+
+```jinja
+{% set greeting = "Hello" %}
+{% set name = "World" %}
+{{ "%s, %s!" | format(greeting, name) }}
+```
+
+**Output**
+
+```jinja
+Hello, World!
+```
+
 ### groupby
 
 Group a sequence of objects by a common attribute:

--- a/src/filters.js
+++ b/src/filters.js
@@ -2,8 +2,11 @@
 
 const lib = require('./lib');
 const r = require('./runtime');
+const { format } = require('node:util');
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+module.exports.format = format;
 
 /**
  * If value is nullish or false, return the default value, otherwise return the

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -2,7 +2,9 @@
 
 const assert = require('node:assert/strict');
 const { describe, it } = require('node:test');
+const { format } = require('node:util');
 const { equal, finish, render } = require('./util');
+const filters = require('../src/filters');
 const lib = require('../src/lib');
 const r = require('../src/runtime');
 
@@ -276,6 +278,12 @@ describe('filter', () => {
   it('forceescape', (t, done) => {
     equal('{{ str | forceescape }}', { str: r.markSafe('<html>') }, '&lt;html&gt;');
     equal('{{ "<html>" | safe | forceescape }}', '&lt;html&gt;');
+    finish(done);
+  });
+
+  it('format', (t, done) => {
+    equal('{{ "%s, %s!" | format(greeting, name) }}', { greeting: 'Hello', name: 'World' }, 'Hello, World!');
+    assert.equal(filters.format, format);
     finish(done);
   });
 


### PR DESCRIPTION
## Summary

Proposed change:

Adding a printf style format filter, like [Jinja2](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.format). Maps directly to the [Node.js format util](https://nodejs.org/docs/latest-v24.x/api/util.html#utilformatformat-args), so may not behave exactly like the python equivalent.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
