### PR TITLE
feat: add xmlattr filter inline with Jinja2 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Adding a printf style format filter, like [Jinja](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.format).
   Maps directly to the [Node.js format util](https://nodejs.org/docs/latest-v24.x/api/util.html#utilformatformat-args),
   so may not behave exactly like the python equivalent. [#11](https://github.com/gunjam/govjucks/pull/11) @gunjam
+* Adding xmlattr filter that matches the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.xmlattr). [#12](https://github.com/gunjam/govjucks/pull/12) @gunjam
 
 ## v0.1.0 (First release)
 

--- a/bench/filters/xmlattr.mjs
+++ b/bench/filters/xmlattr.mjs
@@ -1,0 +1,44 @@
+import { group, summary, bench, run } from 'mitata';
+import gFilters from '../../src/filters.js';
+
+const gXmlattr = gFilters.xmlattr;
+
+summary(() => {
+  group('xmlattr - string', () => {
+    bench('govjucks', () => {
+      gXmlattr({ class: 'govuk-input', name: 'applicant-full-name' });
+    });
+  });
+
+  group('xmlattr - string autospace off', () => {
+    bench('govjucks', () => {
+      gXmlattr({ class: 'govuk-input', name: 'applicant-full-name' }, false);
+    });
+  });
+
+  group('xmlattr - undefined, null', () => {
+    bench('govjucks', () => {
+      gXmlattr({ class: 'govuk-input', name: undefined, value: null });
+    });
+  });
+
+  group('xmlattr - number', () => {
+    bench('govjucks', () => {
+      gXmlattr({ class: 'govuk-input', id: 1, value: 5 });
+    });
+  });
+
+  group('xmlattr - many small', () => {
+    bench('govjucks', () => {
+      gXmlattr({ a: 'b', c: 'd', e: 'f', g: 'h', i: 'j', k: 'l', m: 'n', o: 'p', q: 'r', s: 't', u: 'v' });
+    });
+  });
+
+  group('xmlattr - many small autospace off', () => {
+    bench('govjucks', () => {
+      gXmlattr({ a: 'b', c: 'd', e: 'f', g: 'h', i: 'j', k: 'l', m: 'n', o: 'p', q: 'r', s: 't', u: 'v' }, false);
+    });
+  });
+});
+
+run();

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -2035,6 +2035,36 @@ Count and output the number of words in a string:
 2
 ```
 
+### xmlattr
+
+Create a string of XML attribute key value pairs from an input object. The
+string is rendered with a leading space unless `autospace` is set to `false`.
+
+Attribute values are automatically escaped, attributes with `null` and
+`undefined` values are ignored.
+
+Keys containing a space, `/` solidus, `>` greater-than sign, or `=` equals
+sign will throw a `TemplateError`.
+
+**User input should not be used to generate attribute keys, unless validated
+first.**
+
+**Input**
+
+```jinja
+<input{{ { name: "my-input", disabled: true } | xmlattr }} type="text">
+<div{{ { missing: undefined, id: "item-%d" | format(5) } | xmlattr }}></div>
+<br {{ { "autospace": "off" } | xmlattr(false) }}>
+```
+
+**Output**
+
+```jinja
+<input name="my-input" disabled="true" type="text">
+<div id="item-5"></div>
+<br autospace="off">
+```
+
 Alternatively, it's easy to [read the JavaScript
-code](https://github.com/gunjam/govjucks/blob/master/govjucks/src/filters.js)
+code](https://github.com/gunjam/govjucks/blob/master/src/filters.js)
 that implements these filters.

--- a/src/filters.js
+++ b/src/filters.js
@@ -1074,6 +1074,43 @@ function filesizeformat (value, binary = false) {
 
 module.exports.filesizeformat = filesizeformat;
 
+const invalidKey = /[ />=]/;
+
+/**
+ * Create a string of XML attribute key value pairs from an input object.
+ * @param {Record<string, any>} obj Object map of attribute keys and values
+ * @param {boolean} [autospace=true] Render with leading space (default: true)
+ * @throws {lib.TemplateError}
+ * @returns {string}
+ */
+function xmlattr (obj, autospace = true) {
+  let attrs = autospace ? ' ' : '';
+  let first = true;
+
+  for (const attribute in obj) {
+    const value = obj[attribute];
+
+    if (Object.prototype.hasOwnProperty.call(obj, attribute) &&
+      value !== undefined &&
+      value !== null) {
+      const attrStr = attribute.toString();
+
+      if (invalidKey.test(attrStr)) {
+        throw new lib.TemplateError(
+          `Invalid attribute name: "${attrStr}", cannot contain [ />=]`
+        );
+      }
+
+      attrs += `${first ? '' : ' '}${lib.escape(attrStr)}="${lib.escape(value.toString())}"`;
+      first &&= false;
+    }
+  }
+
+  return new r.SafeString(attrs);
+}
+
+module.exports.xmlattr = xmlattr;
+
 // Aliases
 module.exports.d = module.exports.default;
 module.exports.e = module.exports.escape;

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -1199,4 +1199,71 @@ describe('filter', () => {
     equal('{{ nothing | wordcount }}', '');
     finish(done);
   });
+
+  it('xmlattr', (t, done) => {
+    equal(
+      '{{ { class: "input", id: "name" } | xmlattr }}',
+      ' class="input" id="name"'
+    );
+
+    equal(
+      '{{ { number: 5, missing: undefined, "null": null } | xmlattr }}',
+      ' number="5"'
+    );
+
+    equal(
+      '{{ { boolean: true, boolean2: false } | xmlattr }}',
+      ' boolean="true" boolean2="false"'
+    );
+
+    equal(
+      '{{ { escaped: "< > & \\" \' \\\\" } | xmlattr }}',
+      ' escaped="&lt; &gt; &#38; &#34; &#39; &#92;"'
+    );
+
+    equal(
+      '{{ { "<&\\"\'\\\\": "escaped" } | xmlattr }}',
+      ' &lt;&#38;&#34;&#39;&#92;="escaped"'
+    );
+
+    equal(
+      '{{ { class: "input" } | xmlattr(true) }}',
+      ' class="input"'
+    );
+
+    equal(
+      '{{ { class: "input" } | xmlattr(false) }}',
+      'class="input"'
+    );
+
+    assert.throws(() => {
+      render('{{ { "bad key": "value" } | xmlattr }}');
+    }, {
+      name: 'Template render error',
+      message: /Template render error: Invalid attribute name: "bad key", cannot contain \[ \/>=\]/
+    });
+
+    assert.throws(() => {
+      render('{{ { "bad=key": "value" } | xmlattr }}');
+    }, {
+      name: 'Template render error',
+      message: /Template render error: Invalid attribute name: "bad=key", cannot contain \[ \/>=\]/
+    });
+
+    assert.throws(() => {
+      render('{{ { "bad/key": "value" } | xmlattr }}');
+    }, {
+      name: 'Template render error',
+      message: /Template render error: Invalid attribute name: "bad\/key", cannot contain \[ \/>=\]/
+    });
+
+    assert.throws(() => {
+      render('{{ { "bad>key": "value" } | xmlattr }}');
+    }, {
+      name: 'Template render error',
+      message: /Template render error: Invalid attribute name: "bad>key", cannot contain \[ \/>=\]/
+    });
+
+    finish(done);
+  });
 });


### PR DESCRIPTION
## Summary

Proposed change:

Adding xmlattr filter that matches [the Jinja2 implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.xmlattr).


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
