### PR TITLE
feat: add min and max filters based on Jinja2 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   Maps directly to the [Node.js format util](https://nodejs.org/docs/latest-v24.x/api/util.html#utilformatformat-args),
   so may not behave exactly like the python equivalent. [#11](https://github.com/gunjam/govjucks/pull/11) @gunjam
 * Adding xmlattr filter that matches the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.xmlattr). [#12](https://github.com/gunjam/govjucks/pull/12) @gunjam
+* Adding min & max filters which match the [Jinja min](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.min)
+  and [Jinja max](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.max) versions. [#14](https://github.com/gunjam/govjucks/pull/14) @gunjam
 
 ## v0.1.0 (First release)
 

--- a/bench/filters/max.mjs
+++ b/bench/filters/max.mjs
@@ -1,0 +1,38 @@
+import { group, summary, bench, run } from 'mitata';
+import gFilters from '../../src/filters.js';
+
+const gMax = gFilters.max;
+
+summary(() => {
+  group('max - numbers', () => {
+    bench('govjucks', () => {
+      gMax([5, 4, 1, 3, 8, 2]);
+    });
+  });
+
+  group('max - strings', () => {
+    bench('govjucks', () => {
+      gMax(['AC', 'aa', 'BB', 'ba', 'AB']);
+    });
+  });
+
+  group('max - strings case sensitive', () => {
+    bench('govjucks', () => {
+      gMax(['AC', 'aa', 'BB', 'ba', 'AB'], true);
+    });
+  });
+
+  group('max - attribute', () => {
+    bench('govjucks', () => {
+      gMax([{ prop: 5 }, { prop: 4 }, { prop: 1 }, { prop: 3 }, { prop: 8 }, { prop: 2 }], false, 'prop');
+    });
+  });
+
+  group('max - strings attribute case sensitive', () => {
+    bench('govjucks', () => {
+      gMax([{ prop: 'AC' }, { prop: 'aa' }, { prop: 'BB' }, { prop: 'ba' }, { prop: 'AB' }], false, 'prop');
+    });
+  });
+});
+
+run();

--- a/bench/filters/min.mjs
+++ b/bench/filters/min.mjs
@@ -1,0 +1,38 @@
+import { group, summary, bench, run } from 'mitata';
+import gFilters from '../../src/filters.js';
+
+const gMin = gFilters.min;
+
+summary(() => {
+  group('min - numbers', () => {
+    bench('govjucks', () => {
+      gMin([5, 4, 1, 3, 8, 2]);
+    });
+  });
+
+  group('min - strings', () => {
+    bench('govjucks', () => {
+      gMin(['AC', 'aa', 'BB', 'ba', 'AB']);
+    });
+  });
+
+  group('min - strings case sensitive', () => {
+    bench('govjucks', () => {
+      gMin(['AC', 'aa', 'BB', 'ba', 'AB'], true);
+    });
+  });
+
+  group('min - attribute', () => {
+    bench('govjucks', () => {
+      gMin([{ prop: 5 }, { prop: 4 }, { prop: 1 }, { prop: 3 }, { prop: 8 }, { prop: 2 }], false, 'prop');
+    });
+  });
+
+  group('min - strings attribute case sensitive', () => {
+    bench('govjucks', () => {
+      gMin([{ prop: 'AC' }, { prop: 'aa' }, { prop: 'BB' }, { prop: 'ba' }, { prop: 'AB' }], false, 'prop');
+    });
+  });
+});
+
+run();

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1495,6 +1495,59 @@ Hello World
 Hello missing
 ```
 
+### max
+
+Return the largest value in an array of numbers or strings.
+
+For strings the comparison is case-insensitive by default, but can be made
+case-sensitive by setting `case_sensitive` as `true`.
+
+`max` can also be used on lists of objects by specifying a property to compare
+with the `attribute` parameter.
+
+**Input**
+
+```jinja
+{{ [4, 2, 5, 1, 0] | max }}
+---
+{{ ["cat", "Dog", "Bird"] | max }}
+{{ ["cat", "Dog", "Bird"] | max(true) }}
+{{ ["cat", "Dog", "Bird"] | max(case_sensitive=true) }}
+---
+{%- set data = [{ animal: "cat" }, { animal: "Dog" }, { animal: "Bird" }] %}
+{{ data | max(attribute="animal") | dump | safe }}
+{{ data | max(true, "animal") | dump | safe }}
+```
+
+**Output**
+
+```jinja
+5
+---
+Dog
+cat
+cat
+---
+{"animal":"Dog"}
+{"animal":"cat"}
+```
+
+### min
+
+Same as `max` but returns the smallest value instead.
+
+**Input**
+
+```jinja
+{{ [4, 2, 5, 1, 0] | min }}
+```
+
+**Output**
+
+```jinja
+0
+```
+
 ### nl2br
 
 Replace new lines with `<br />` HTML elements:

--- a/src/filters.js
+++ b/src/filters.js
@@ -1111,6 +1111,73 @@ function xmlattr (obj, autospace = true) {
 
 module.exports.xmlattr = xmlattr;
 
+/** @param {boolean} check */
+function minMax (check) {
+  /**
+   * @param {number[] | string[] | Record<string, number>[] | Record<string, string>[]} array
+   * @param {boolean} [caseSensitive=false]
+   * @param {string} [attribute]
+   */
+  function find (array, caseSensitive, attribute) {
+    caseSensitive ??= false;
+
+    let min = array[0];
+    let minCompare = attribute ? min?.[attribute] : min;
+    minCompare = !caseSensitive && typeof minCompare === 'string'
+      ? minCompare.toLowerCase()
+      : minCompare;
+
+    for (let i = 1, len = array.length; i < len; i++) {
+      let vc = attribute ? array[i]?.[attribute] : array[i];
+      if (caseSensitive) {
+        if ((vc < minCompare) === check) {
+          min = array[i];
+          minCompare = vc;
+        }
+      } else {
+        vc = typeof vc === 'string' ? vc.toLowerCase() : vc;
+        if ((vc < minCompare) === check) {
+          min = array[i];
+          minCompare = vc;
+        }
+      }
+    }
+
+    return min;
+  }
+
+  return r.makeMacro(['value', 'case_sensitive', 'attribute'], find);
+}
+
+/**
+ * Get the smallest item in a list of strings or numbers. For strings the
+ * comparison is case-insensitive by default, but can be made case-sensitive by
+ * passing `true` as the `caseSensitive` argument.
+ *
+ * For lists of objects, the `attribute` argument can be used to specify a
+ * property to compare.
+ * @param {number[] | string[] | Record<string, number>[] | Record<string, string>[]} array
+ * @param {boolean} [caseSensitive=false]
+ * @param {string} [attribute]
+ */
+const min = minMax(true);
+
+/**
+ * Get the largest item in a list of strings or numbers. For strings the
+ * comparison is case-insensitive by default, but can be made case-sensitive by
+ * passing `true` as the `caseSensitive` argument.
+ *
+ * For lists of objects, the `attribute` argument can be used to specify a
+ * property to compare.
+ * @param {number[] | string[] | Record<string, number>[] | Record<string, string>[]} array
+ * @param {boolean} [caseSensitive=false]
+ * @param {string} [attribute]
+ */
+const max = minMax(false);
+
+module.exports.min = min;
+module.exports.max = max;
+
 // Aliases
 module.exports.d = module.exports.default;
 module.exports.e = module.exports.escape;

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -696,6 +696,118 @@ describe('filter', () => {
     });
   });
 
+  it('max', (t, done) => {
+    // Numbers
+    equal('{{ [5, 4, 1, 3, 8, 2] | max }}', '8');
+    equal('{{ [5, 4.3, 1, 8.5, 8, 2] | max }}', '8.5');
+
+    // Strings
+    equal('{{ ["AC", "aa", "BB", "ba", "AB"] | max }}', 'BB');
+
+    // Case-sensitive (a > A)
+    equal('{{ ["AC", "aa", "BB", "ba", "AB"] | max(true) }}', 'ba');
+    equal('{{ ["AC", "aa", "BB", "ba", "AB"] | max(case_sensitive=true) }}', 'ba');
+
+    // Attribute
+    equal('{{ data | max(false, "prop") | dump | safe }}', {
+      data: [
+        { prop: 5 },
+        { prop: 4 },
+        { prop: 1 },
+        { prop: 3 },
+        { prop: 8 },
+        { prop: 2 }
+      ]
+    }, '{"prop":8}');
+    equal('{{ data | max(attribute="prop") | dump | safe }}', {
+      data: [
+        { prop: 5 },
+        { prop: 4 },
+        { prop: 1 },
+        { prop: 3 },
+        { prop: 8 },
+        { prop: 2 }
+      ]
+    }, '{"prop":8}');
+
+    equal('{{ data | max(false, "prop") | dump | safe }}', {
+      data: [
+        { prop: 'AC' },
+        { prop: 'aa' },
+        { prop: 'BB' },
+        { prop: 'ba' },
+        { prop: 'AB' }
+      ]
+    }, '{"prop":"BB"}');
+    equal('{{ data | max(attribute="prop") | dump | safe }}', {
+      data: [
+        { prop: 'AC' },
+        { prop: 'aa' },
+        { prop: 'BB' },
+        { prop: 'ba' },
+        { prop: 'AB' }
+      ]
+    }, '{"prop":"BB"}');
+
+    finish(done);
+  });
+
+  it('min', (t, done) => {
+    // Numbers
+    equal('{{ [5, 4, 1, 3, 8, 2] | min }}', '1');
+    equal('{{ [5, 4.3, 1, 8.5, 8, 2] | min }}', '1');
+
+    // Strings
+    equal('{{ ["AC", "aa", "BB", "ba", "AB"] | min }}', 'aa');
+
+    // Case-sensitive (A < a)
+    equal('{{ ["AC", "aa", "BB", "ba", "AB"] | min(true) }}', 'AB');
+    equal('{{ ["AC", "aa", "BB", "ba", "AB"] | min(case_sensitive=true) }}', 'AB');
+
+    // Attribute
+    equal('{{ data | min(false, "prop") | dump | safe }}', {
+      data: [
+        { prop: 5 },
+        { prop: 4 },
+        { prop: 1 },
+        { prop: 3 },
+        { prop: 8 },
+        { prop: 2 }
+      ]
+    }, '{"prop":1}');
+    equal('{{ data | min(attribute="prop") | dump | safe }}', {
+      data: [
+        { prop: 5 },
+        { prop: 4 },
+        { prop: 1 },
+        { prop: 3 },
+        { prop: 8 },
+        { prop: 2 }
+      ]
+    }, '{"prop":1}');
+
+    equal('{{ data | min(false, "prop") | dump | safe }}', {
+      data: [
+        { prop: 'AC' },
+        { prop: 'aa' },
+        { prop: 'BB' },
+        { prop: 'ba' },
+        { prop: 'AB' }
+      ]
+    }, '{"prop":"aa"}');
+    equal('{{ data | min(attribute="prop") | dump | safe }}', {
+      data: [
+        { prop: 'AC' },
+        { prop: 'aa' },
+        { prop: 'BB' },
+        { prop: 'ba' },
+        { prop: 'AB' }
+      ]
+    }, '{"prop":"aa"}');
+
+    finish(done);
+  });
+
   it('nl2br', (t, done) => {
     equal('{{ null | nl2br }}', '');
     equal('{{ undefined | nl2br }}', '');


### PR DESCRIPTION
## Summary

Proposed change:

Adding min & max filters which match the [Jinja2 min](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.min) and [Jinja2 max](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.max) versions.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
