### PR TITLE
feat: add tojson filter to stringify and escape values to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Adding xmlattr filter that matches the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.xmlattr). [#12](https://github.com/gunjam/govjucks/pull/12) @gunjam
 * Adding min & max filters which match the [Jinja min](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.min)
   and [Jinja max](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.max) versions. [#14](https://github.com/gunjam/govjucks/pull/14) @gunjam
+* Adding tojson filter based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.tojson). [#15](https://github.com/gunjam/govjucks/pull/15) @gunjam
 
 ## v0.1.0 (First release)
 

--- a/bench/filters/tojson.mjs
+++ b/bench/filters/tojson.mjs
@@ -1,0 +1,44 @@
+import { group, summary, bench, run, do_not_optimize } from 'mitata';
+import gFilters from '../../src/filters.js';
+
+const gTojson = gFilters.tojson;
+
+summary(() => {
+  group('tojson - undefined', () => {
+    bench('govjucks', () => {
+      do_not_optimize(gTojson(undefined));
+    });
+  });
+
+  group('tojson - string', () => {
+    bench('govjucks', () => {
+      gTojson("some kind of test string");
+    });
+  });
+
+  group('tojson - string needs escaping', () => {
+    bench('govjucks', () => {
+      gTojson("<script>alert('bad')</script>");
+    });
+  });
+
+  group('tojson - object', () => {
+    bench('govjucks', () => {
+      gTojson({
+        property: "value",
+        nested: { property: "value" }
+      });
+    });
+  });
+
+  group('tojson - object indented', () => {
+    bench('govjucks', () => {
+      gTojson({
+        property: "value",
+        nested: { property: "value" }
+      }, 2);
+    });
+  });
+});
+
+run();

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1955,6 +1955,51 @@ Make the first letter of the string uppercase:
 Foo Bar Baz
 ```
 
+### tojson
+
+Serialize an input value to a JSON string, escape any special characters and
+mark it as safe.
+
+The returned string is safe to use in `<script>` tags and in HTML, except in
+attribute values that use double quotes - either use single quotes or the
+`| escape` filter.
+
+You can use the indent argument to set the number of spaces for formatting.
+
+**Input**
+
+```jinja
+{{ "foo bar baz" | tojson }}
+{%- set str = '""</script><script>alert("hello")</script>' %}
+<script>
+  const str = {{ str | tojson }}
+</script>
+{{ undefined | tojson }}
+{%- set obj = {
+  property: "value",
+  nested: { property: "value" }
+} %}
+{{ obj | tojson }}
+{{ obj | tojson(2) }}
+```
+
+**Output**
+
+```jinja
+"foo bar baz"
+<script>
+  const str = "\"\"\u003c/script\u003e\u003cscript\u003ealert(\"hello\")\u003c/script\u003e"
+</script>
+
+{"property":"value","nested":{"property":"value"}}
+{
+  "property": "value",
+  "nested": {
+    "property": "value"
+  }
+}
+```
+
 ### trim
 
 Strip leading and trailing whitespace:

--- a/src/filters.js
+++ b/src/filters.js
@@ -1178,6 +1178,25 @@ const max = minMax(false);
 module.exports.min = min;
 module.exports.max = max;
 
+/**
+ * Stringfy an input value using `JSON.stringify()` and escape it for use
+ * within a `<script>` tag. Values that are `undefined` will return an empty
+ * string.
+ * @param {any} value Input value
+ * @param {number} [indent] Number of spaces to indent the JSON string.
+ * @returns {string} Escaped JSON string.
+ */
+function tojson (value, indent) {
+  if (value === undefined) {
+    return '';
+  }
+
+  const spaces = indent ? ' '.repeat(indent) : '';
+  return new r.SafeString(lib.escapeJSON(JSON.stringify(value, null, spaces)));
+}
+
+module.exports.tojson = tojson;
+
 // Aliases
 module.exports.d = module.exports.default;
 module.exports.e = module.exports.escape;

--- a/src/lib.js
+++ b/src/lib.js
@@ -57,6 +57,50 @@ const escapeFunction = (string) => {
 
 module.exports.escape = escapeFunction;
 
+const JSONescapeRegExp = /[&'<>]/g;
+/**
+ * Escapes stringfied JSON so it cane safely rendered within a `<script>` tag
+ * @param {string} string
+ * @returns {string} escaped string
+ */
+const escapeJSON = (string) => {
+  let escaped = '';
+  let start = 0;
+
+  while (JSONescapeRegExp.test(string)) {
+    const i = JSONescapeRegExp.lastIndex - 1;
+
+    switch (string.charCodeAt(i)) {
+      // &
+      case 38: {
+        escaped += string.slice(start, i) + '\\u0026';
+        break;
+      }
+      // '
+      case 39: {
+        escaped += string.slice(start, i) + '\\u0027';
+        break;
+      }
+      // <
+      case 60: {
+        escaped += string.slice(start, i) + '\\u003c';
+        break;
+      }
+      // >
+      case 62: {
+        escaped += string.slice(start, i) + '\\u003e';
+        break;
+      }
+    }
+
+    start = JSONescapeRegExp.lastIndex;
+  }
+
+  return escaped + string.slice(start);
+};
+
+module.exports.escapeJSON = escapeJSON;
+
 function _prettifyError (path, withInternals, err) {
   if (!err.Update) {
     // not one of ours, cast it

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -1142,6 +1142,33 @@ describe('filter', () => {
     finish(done);
   });
 
+  it('tojson', (t, done) => {
+    equal('{{ "foo bar baz" | tojson }}', '"foo bar baz"');
+    equal('{{ true | tojson }}', 'true');
+    equal('{{ false | tojson }}', 'false');
+    equal('{{ null | tojson }}', 'null');
+    equal('{{ 5 | tojson }}', '5');
+    equal('{{ undefined | tojson }}', '');
+    equal('{{ nothing | tojson }}', '');
+    equal('{{ [5, "test", true] | tojson }}', '[5,"test",true]');
+
+    const obj = {
+      property: 'value',
+      nested: { property: 'value' }
+    };
+    equal('{{ obj | tojson }}', { obj }, '{"property":"value","nested":{"property":"value"}}');
+    equal('{{ obj | tojson(2) }}', { obj }, `{
+  "property": "value",
+  "nested": {
+    "property": "value"
+  }
+}`);
+
+    // Escaping
+    equal('{{ "& \' < >" | tojson }}', '"\\u0026 \\u0027 \\u003c \\u003e"');
+    finish(done);
+  });
+
   it('trim', (t, done) => {
     equal('{{ "  foo " | trim }}', 'foo');
     equal('{{ str | trim }}', {


### PR DESCRIPTION
## Summary

Proposed change:

Adding tojson filter based on the [Jinja2 implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.tojson)

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
