### PR TITLE
feat: add more test functions for better feature parity with jinja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Added unique filter based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.tojson). [#16](https://github.com/gunjam/govjucks/pull/16) @gunjam
 * Added lipsum global function based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-globals.lipsum). [#18](https://github.com/gunjam/govjucks/pull/18) @gunjam
 * Add alias of `count` to `length` filter. [#21](https://github.com/gunjam/govjucks/pull/21) @gunjam
+* Added tests that are in Jinja but missing from nunjucks. Add missing test documentation. [#17](https://github.com/gunjam/govjucks/pull/17) @gunjam
 
 ## v0.1.0 (First release)
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -251,6 +251,40 @@ env.getFilter(name)
 Get the filter, which is just a function, named **name**.
 
 
+### `hasFilter()`
+```js
+env.hasFilter(name)
+```
+
+Returns `true` if the filter named **name** exists.
+
+
+### `addTest()`
+```js
+env.addTest(name, func)
+```
+
+Add a custom test named **name** which calls **func** whenever
+invoked. Returns `env` for further method chaining. See
+[Custom Tests](#custom-tests).
+
+
+### `getTest()`
+```js
+env.getTest(name)
+```
+
+Get the test, which is just a function, named **name**.
+
+
+### `hasTest()`
+```js
+env.hasFilter(name)
+```
+
+Returns `true` if the test named **name** exists.
+
+
 ### `addExtension()`
 ```js
 env.addExtension(name, ext)
@@ -812,10 +846,35 @@ is used:
 
 ```jinja
 {# Show the first 5 characters #}
-A message for you: {{ message|shorten }}
+A message for you: {{ message | shorten }}
 
 {# Show the first 20 characters #}
-A message for you: {{ message|shorten(20) }}
+A message for you: {{ message | shorten(20) }}
+```
+
+## Custom Tests
+
+To add a custom test, use the `Environment` method `addTest`.
+A test can be used as an expression in `if` block and like a filter is simply a
+function where the left value is passed as the argument and any on the right are
+passed as the second, third, etc. in order.
+
+```js
+const govjucks = require('govjucks');
+const env = new govjucks.Environment();
+
+env.addTest('factorof', function (factor, num) {
+  return num % factor === 0;
+});
+```
+
+This adds a test `factorof` which is true if the left value is a factor of the
+right's:
+
+```jinja
+{% if num is factorof 12 %}
+  {{ num }}
+{% endif %}
 ```
 
 ### Keyword/Default Arguments

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -81,9 +81,23 @@ They are called with a pipe operator (`|`) and can take arguments.
 The third example shows how you can chain filters. It would display
 "Bar", by first replacing "foo" with "bar" and then capitalizing it.
 
-Govjucks comes with several
-[builtin filters](#builtin-filters), and you can
+Govjucks comes with several [builtin filters](#builtin-filters), and you can
 [add your own](api#custom-filters) as well.
+
+## Tests
+
+As well as filters, there are also “tests” that can be used to test
+a variable in an expression. Like filters, tests are functions but they are
+called using `is` and can also take arguments. If there is only one argument you
+don't need to include the parentheses:
+
+```jinja
+{% if number is greaterthan 3 %}{% endif %}
+{% if number is greaterthan(3) %}{% endif %}
+```
+
+Govjucks comes with several [builtin tests](#builtin-tests), and you can
+[add your own](api#custom-tests) as well.
 
 ## Template Inheritance
 
@@ -1454,7 +1468,6 @@ Aliases: `count`.
 1
 ```
 
-
 ### list
 
 Convert the value into a list.
@@ -2189,7 +2202,6 @@ Truncate URL text by a given number:
 <a href="http://mozilla.github.io/">http://moz</a>
 ```
 
-
 ### wordcount
 
 Count and output the number of words in a string:
@@ -2240,3 +2252,266 @@ first.**
 Alternatively, it's easy to [read the JavaScript
 code](https://github.com/gunjam/govjucks/blob/master/src/filters.js)
 that implements these filters.
+
+## Builtin tests
+
+### boolean
+
+Returns true if the input var is a boolean.
+
+```jinja
+{% if foo is boolean %}
+```
+
+### callable
+
+Returns true if the input is “callable”, eg: a function.
+
+```jinja
+{% if foo is callable %}
+```
+
+### defined
+
+Returns true if the input is defined, either in the context or with a
+`{% set% }` call.
+
+```jinja
+{% if foo is defined %}
+```
+
+### divisibleby
+
+Check if a number is disivible by another.
+
+```jinja
+{% if foo is divisibleby 3 %}
+{% if foo is divisibleby(3) %}
+```
+
+## escaped
+
+Checked if the value is escaped, for example has been passed through the
+`| escape` filter.
+
+```jinja
+{% if foo is escaped %}
+```
+
+## eq
+
+Same as `==`.
+
+Aliases: `equalto`, `sameas`.
+
+```jinja
+{% if foo is eq "bar" %}
+{% if foo is equalto "bar" %}
+{% if foo is sameas "bar" %}
+```
+
+## even
+
+True if the input is an even number.
+
+```jinja
+{% if number is even %}
+```
+
+## false
+
+True if the input is equal to boolean `false`.
+
+```jinja
+{% if bool is false %}
+```
+
+## falsy
+
+Returns `true` if the value is JavaScript falsy: `''`, `0`, `false`,
+`undefined`, `NaN` or `null`.
+
+```jinja
+{% if value is falsy %}
+```
+
+## filter
+
+Check if a named filter exists, useful if a filter may be optionally available.
+
+```jinja
+{% if "markdown" is filter %}
+  {{ value | markdown }}
+{% else %}
+  {{ value }}
+{% endif %}
+```
+
+## float
+
+True if a number is a float.
+
+```jinja
+{% if number is float %}
+```
+
+## ge
+
+True if a number is a greater than or equal to another. Same as `a >= b`.
+
+```jinja
+{% if number is ge 8 %}
+```
+
+## gt
+
+True if a number is a greater than another. Same as `a > b`.
+
+Aliases: `greaterthan`.
+
+```jinja
+{% if number is gt 7 %}
+{% if number is greaterthan 7 %}
+```
+
+## in
+
+Check if a value is in an iterable, such as an Array, Set or Map, or that a key
+is in an object.
+
+```jinja
+{% if "key" is in obj %}
+{% if 5 is in arr %}
+```
+
+## integer
+
+True if the value is an integer.
+
+```jinja
+{% if 4 is integer %}
+```
+ ## iterable
+ 
+ True if a value is an iterable, such as an Array, Set or Map, or has a
+ `[Symbol.iterator]()` [method](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol).
+
+## le
+
+True if a number is a less than or equal to another. Same as `a <= b`.
+
+```jinja
+{% if number is le 8 %}
+```
+
+## lower
+
+True if a string is in lowercase.
+
+```jinja
+{% if "string" is lower %}
+```
+
+## lt
+
+True if a number is a less than another. Same as `a < b`.
+
+Aliase: `lessthan`.
+
+```jinja
+{% if number is lt 8 %}
+{% if number is lessthan 8 %}
+```
+
+## mapping
+
+True if a value is an object or Map.
+
+```jinja
+{% if obj is mapping %}
+```
+
+## ne
+
+True if a value is not equal to another. Same as `a != b`.
+
+```jinja
+{% if foo is ne bar %}
+```
+
+## null
+
+True if a value is `null`.
+
+```jinja
+{% if val is null %}
+```
+
+## number
+
+True if a value is a number.
+
+```jinja
+{% if val is number %}
+```
+
+## odd
+
+True if a number is odd.
+
+```jinja
+{% if num is odd %}
+```
+
+## odd
+
+True if a number is odd.
+
+```jinja
+{% if num is odd %}
+```
+
+## string
+
+True if a value is a string.
+
+```jinja
+{% if val is string %}
+```
+
+## test
+
+Check if a test exists for a given name, useful if a test is optionally
+available.
+
+```jinja
+{% if "loud" is test %}
+  {% if value is loud %}
+    {{ value | upper }}
+  {% else %}
+    {{ value | lower }}
+  {% endif %}
+{% else %}
+  {{ value }}
+{% endif %}
+```
+
+## undefined
+
+Check if a variable is `undefined`.
+
+```jinja
+{% if var is undefined %}
+```
+
+## upper
+
+Check if a string is in uppercase.
+
+```jinja
+{% if str is uppercase %}
+```
+
+You can also [read the JavaScript
+code](https://github.com/gunjam/govjucks/blob/master/govjucks/src/tests.js)
+that implements the tests.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "James Long <longster@gmail.com>",
   "dependencies": {
     "asap": "^2.0.6",
-    "fastfall": "^1.5.1"
+    "fastfall": "^1.5.1",
+    "is-plain-obj": "^4.1.0"
   },
   "type": "commonjs",
   "devDependencies": {

--- a/src/environment.js
+++ b/src/environment.js
@@ -170,6 +170,10 @@ class Environment extends EmitterObj {
     return this;
   }
 
+  hasFilter (name) {
+    return name && (name in this.filters);
+  }
+
   getFilter (name) {
     if (!this.filters[name]) {
       throw new Error('filter not found: ' + name);
@@ -180,6 +184,10 @@ class Environment extends EmitterObj {
   addTest (name, func) {
     this.tests[name] = func;
     return this;
+  }
+
+  hasTest (name) {
+    return name && (name in this.tests);
   }
 
   getTest (name) {

--- a/src/environment.js
+++ b/src/environment.js
@@ -145,7 +145,7 @@ class Environment extends EmitterObj {
   }
 
   hasExtension (name) {
-    return !!this.extensions[name];
+    return Object.hasOwn(this.extensions, name);
   }
 
   addGlobal (name, value) {
@@ -171,7 +171,7 @@ class Environment extends EmitterObj {
   }
 
   hasFilter (name) {
-    return name && (name in this.filters);
+    return Object.hasOwn(this.filters, name);
   }
 
   getFilter (name) {
@@ -187,7 +187,7 @@ class Environment extends EmitterObj {
   }
 
   hasTest (name) {
-    return name && (name in this.tests);
+    return Object.hasOwn(this.tests, name);
   }
 
   getTest (name) {

--- a/src/tests.js
+++ b/src/tests.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const isPlainObj = require('is-plain-obj').default;
 const SafeString = require('./runtime').SafeString;
 
 /**
@@ -361,10 +362,7 @@ exports.iterable = iterable;
  */
 function mapping (value) {
   // only maps and object hashes
-  return value !== null &&
-    typeof value === 'object' &&
-    !Array.isArray(value) &&
-    !(value instanceof Set);
+  return isPlainObj(value) || value instanceof Map;
 }
 
 exports.mapping = mapping;

--- a/src/tests.js
+++ b/src/tests.js
@@ -3,6 +3,17 @@
 const SafeString = require('./runtime').SafeString;
 
 /**
+ * Returns `true` if the input is a boolean, otherwise `false`.
+ * @param { any } value
+ * @returns { boolean }
+ */
+function boolean (value) {
+  return typeof value === 'boolean';
+}
+
+exports.boolean = boolean;
+
+/**
  * Returns `true` if the object is a function, otherwise `false`.
  * @param { any } value
  * @returns { boolean }
@@ -75,6 +86,17 @@ function even (value) {
 exports.even = even;
 
 /**
+ * Returns `true` if the input is `false`, otherwise `false`.
+ * @param { any } value
+ * @returns { boolean }
+ */
+function isFalse (value) {
+  return value === false;
+}
+
+exports.false = isFalse;
+
+/**
  * Returns `true` if the value is falsy - if I recall correctly, '', 0, false,
  * undefined, NaN or null. I don't know if we should stick to the default JS
  * behavior or attempt to replicate what Python believes should be falsy (i.e.,
@@ -87,6 +109,28 @@ function falsy (value) {
 }
 
 exports.falsy = falsy;
+
+/**
+ * Returns `true` if a filter exists for the given name, otherwise `false`.
+ * @param { string } value
+ * @returns { boolean }
+ */
+function filter (value) {
+  return this.env.hasFilter(value);
+}
+
+exports.filter = filter;
+
+/**
+ * Returns `true` if a value is a float, otherwise `false`.
+ * @param { any } value
+ * @returns { boolean }
+ */
+function float (value) {
+  return Number(value) && !Number.isInteger(value);
+}
+
+exports.float = float;
 
 /**
  * Returns `true` if the operand (one) is greater or equal to the test's
@@ -116,6 +160,34 @@ exports.greaterthan = greaterthan;
 
 // alias
 exports.gt = exports.greaterthan;
+
+/**
+ * Returns `true` if a value is in an object, otherwise `false`.
+ * @param { any } value
+ * @returns { boolean }
+ */
+function inArr (value, arr) {
+  if (Array.isArray(arr)) {
+    return arr.includes(value);
+  }
+  if (arr instanceof Map || arr instanceof Set) {
+    return arr.has(value);
+  }
+  return typeof arr === 'object' && (value in arr);
+}
+
+exports.in = inArr;
+
+/**
+ * Returns `true` if a value is an integer, otherwise `false`.
+ * @param { any } value
+ * @returns { boolean }
+ */
+function integer (value) {
+  return Number.isInteger(value);
+}
+
+exports.integer = integer;
 
 /**
  * Returns `true` if the operand (one) is less than or equal to the test's
@@ -213,6 +285,28 @@ function string (value) {
 }
 
 exports.string = string;
+
+/**
+ * Returns `true` if a test exists for the given name, otherwise `false`.
+ * @param { string } value
+ * @returns { boolean }
+ */
+function test (value) {
+  return this.env.hasTest(value);
+}
+
+exports.test = test;
+
+/**
+ * Returns `true` if the input is `true`, otherwise `false`.
+ * @param { any } value
+ * @returns { boolean }
+ */
+function isTrue (value) {
+  return value === true;
+}
+
+exports.true = isTrue;
 
 /**
  * Returns `true` if the value is not in the list of things considered falsy:

--- a/tests/tests.test.js
+++ b/tests/tests.test.js
@@ -3,6 +3,7 @@
 const assert = require('node:assert/strict');
 const { describe, it } = require('node:test');
 const { equal, render } = require('./util');
+const NullObject = require('../src/null-object');
 
 describe('tests', () => {
   it('boolean should detect booleans', () => {
@@ -131,22 +132,20 @@ describe('tests', () => {
   });
 
   it('mapping should detect Maps or hashes', () => {
-    /* global Map */
-    let map1, map2, mapOneIsMapping, mapTwoIsMapping;
-    if (typeof Map === 'undefined') {
-      this.skip();
-    } else {
-      map1 = new Map();
-      map2 = {};
-      mapOneIsMapping = render('{{ map is mapping }}', {
-        map: map1
-      });
-      mapTwoIsMapping = render('{{ map is mapping }}', {
-        map: map2
-      });
-      assert.equal(mapOneIsMapping, 'true');
-      assert.equal(mapTwoIsMapping, 'true');
-    }
+    // Map and plain/null objects
+    equal('{{ map is mapping }}', { map: new Map() }, 'true');
+    equal('{{ map is mapping }}', { map: {} }, 'true');
+    equal('{{ map is mapping }}', { map: new NullObject() }, 'true');
+
+    // Not valid mappings
+    equal('{{ map is mapping }}', { map: new Set() }, 'false');
+    equal('{{ map is mapping }}', { map: [] }, 'false');
+    equal('{{ map is mapping }}', { map: new Date() }, 'false');
+    equal('{{ map is mapping }}', { map: 'string' }, 'false');
+    equal('{{ map is mapping }}', { map: null }, 'false');
+    equal('{{ map is mapping }}', { map: undefined }, 'false');
+    equal('{{ map is mapping }}', { map: 1 }, 'false');
+    equal('{{ map is mapping }}', { map: true }, 'false');
   });
 
   it('false should detect whether or not a value is false', () => {

--- a/tests/tests.test.js
+++ b/tests/tests.test.js
@@ -5,6 +5,31 @@ const { describe, it } = require('node:test');
 const { equal, render } = require('./util');
 
 describe('tests', () => {
+  it('boolean should detect booleans', () => {
+    const boolTrue = render('{{ foo is boolean }}', {
+      foo: true
+    });
+    const notBoolTrue = render('{{ foo is not boolean }}', {
+      foo: true
+    });
+    const boolFalse = render('{{ foo is boolean }}', {
+      foo: false
+    });
+    const string = render('{{ foo is boolean }}', {
+      foo: 'true'
+    });
+    const notString = render('{{ foo is not boolean }}', {
+      foo: 'true'
+    });
+    const missing = render('{{ foo is boolean }}');
+    assert.equal(boolTrue, 'true');
+    assert.equal(notBoolTrue, 'false');
+    assert.equal(boolFalse, 'true');
+    assert.equal(string, 'false');
+    assert.equal(notString, 'true');
+    assert.equal(missing, 'false');
+  });
+
   it('callable should detect callability', () => {
     const callable = render('{{ foo is callable }}', {
       foo () {
@@ -124,11 +149,49 @@ describe('tests', () => {
     }
   });
 
+  it('false should detect whether or not a value is false', () => {
+    const zero = render('{{ 0 is false }}');
+    const boolFalse = render('{{ false is false }}');
+    const boolTrue = render('{{ true is false }}');
+    const pancakes = render('{{ "pancakes" is not false }}');
+    assert.equal(zero, 'false');
+    assert.equal(boolFalse, 'true');
+    assert.equal(boolTrue, 'false');
+    assert.equal(pancakes, 'true');
+  });
+
   it('falsy should detect whether or not a value is falsy', () => {
     const zero = render('{{ 0 is falsy }}');
     const pancakes = render('{{ "pancakes" is not falsy }}');
     assert.equal(zero, 'true');
     assert.equal(pancakes, 'true');
+  });
+
+  it('filter should detect whether or not a value is a filter', () => {
+    const zero = render('{{ 0 is filter }}');
+    const filter = render('{{ "upper" is filter }}');
+    const pancakes = render('{{ "pancakes" is not filter }}');
+    assert.equal(zero, 'false');
+    assert.equal(filter, 'true');
+    assert.equal(pancakes, 'true');
+  });
+
+  it('float should detect whether or not a value is a float', () => {
+    const zero = render('{{ 0 is float }}');
+    const onePointOne = render('{{ 1.1 is float }}');
+    const pancakes = render('{{ "pancakes" is not float }}');
+    assert.equal(zero, 'false');
+    assert.equal(onePointOne, 'true');
+    assert.equal(pancakes, 'true');
+  });
+
+  it('true should detect whether or not a value is true', () => {
+    const nullTruthy = render('{{ null is true }}');
+    const trueTrue = render('{{ true is true }}');
+    const pancakesNotTrue = render('{{ "pancakes" is not true }}');
+    assert.equal(nullTruthy, 'false');
+    assert.equal(trueTrue, 'true');
+    assert.equal(pancakesNotTrue, 'true');
   });
 
   it('truthy should detect whether or not a value is truthy', () => {
@@ -173,12 +236,56 @@ describe('tests', () => {
     assert.equal(four, 'false');
   });
 
+  it('in should detect a value is in an array', () => {
+    const fiveIn = render('{{ 5 is in([1, 2, 3, 4, 5]) }}');
+    const sixIn = render('{{ 6 is in([1, 2, 3, 4, 5]) }}');
+    const fourVal = render('{{ 4 is not in(arr) }}', { arr: [1, 2, 3, 4, 5] });
+    const map = render('{{ "key" is in(map) }}', {
+      map: new Map([['key', 'value']])
+    });
+    const mapNo = render('{{ "key" is in(map) }}', {
+      map: new Map([['test', 'value']])
+    });
+    const set = render('{{ "item" is in(set) }}', {
+      set: new Set(['item'])
+    });
+    const setNo = render('{{ "item" is in(set) }}', {
+      set: new Set(['pie'])
+    });
+    const obj = render('{{ "key" is in(obj) }}', {
+      obj: { key: 'value' }
+    });
+    const objNo = render('{{ "key" is in(obj) }}', {
+      obj: {}
+    });
+    const missing = render('{{ 4 is in(arr) }}');
+    assert.equal(fiveIn, 'true');
+    assert.equal(sixIn, 'false');
+    assert.equal(fourVal, 'false');
+    assert.equal(map, 'true');
+    assert.equal(mapNo, 'false');
+    assert.equal(set, 'true');
+    assert.equal(setNo, 'false');
+    assert.equal(obj, 'true');
+    assert.equal(objNo, 'false');
+    assert.equal(missing, 'false');
+  });
+
+  it('integer should detect whether or not a value is an integer', () => {
+    const zero = render('{{ 0 is integer }}');
+    const onePointOne = render('{{ 1.1 is integer }}');
+    const pancakes = render('{{ "pancakes" is not integer }}');
+    assert.equal(zero, 'true');
+    assert.equal(onePointOne, 'false');
+    assert.equal(pancakes, 'true');
+  });
+
   it('iterable should detect that a generator is iterable', (t, done) => {
     let iterable;
     try {
       /* eslint-disable-next-line no-eval */
       iterable = eval('(function* iterable() { yield true; })()');
-    } catch (e) {
+    } catch {
       return this.skip(); // Browser does not support generators
     }
     equal('{{ fn is iterable }}', { fn: iterable }, 'true');
@@ -244,5 +351,14 @@ describe('tests', () => {
   it('upper should detect whether or not a string is uppercased', () => {
     assert.equal(render('{{ "FOOBAR" is upper }}'), 'true');
     assert.equal(render('{{ "Foobar" is upper }}'), 'false');
+  });
+
+  it('test should detect whether or not a value is a test', () => {
+    const zero = render('{{ 0 is test }}');
+    const test = render('{{ "falsy" is test }}');
+    const pancakes = render('{{ "pancakes" is not test }}');
+    assert.equal(zero, 'false');
+    assert.equal(test, 'true');
+    assert.equal(pancakes, 'true');
   });
 });


### PR DESCRIPTION
## Summary

Adding the following tests that are Jinja but missing from govjucks: boolean, `false`, `filter`, `float`, `in`, `integer`, `test` and `true`.

Improved `mapping` test to only return true for `Map`s and plain/null objects.

Also updated the documentation as there is currently no docs for tests at all.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
