### PR TITLE
fix: result of inline if with no else should be `undefined` when falsy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 * `in` operator should return `false` rather than throw on `undefined` values, consistent with Jinja. [#22](https://github.com/gunjam/govjucks/pull/22) @gunjam
+* Inline `if` with no `else` should return `undefined` when the expression is falsy, matching the [Jinja if behavior](https://jinja.palletsprojects.com/en/stable/templates/#if-expression). [#19](https://github.com/gunjam/govjucks/pull/19) @gunjam
 
 ## v0.2.0
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -844,6 +844,8 @@ Unlike javascript's ternary operator, the `else` is optional:
 {{ "true" if foo }}
 ```
 
+If `foo` is falsy, the output will be `undefined`.
+
 ### Function Calls
 
 If you have passed a javascript method to your template, you can call it like

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -436,7 +436,7 @@ class Compiler {
     if (node.else_ !== null) {
       this.compile(node.else_, frame);
     } else {
-      this._emit('""');
+      this._emit('undefined');
     }
     this._emit(')');
   }

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1102,10 +1102,22 @@ class Compiler {
       currFrame = new Frame();
     }
 
-    this._emitLines(`function ${funcId}(${funcArgs.join(', ')}) {`);
+    // Check if this macro is at the top, if so all nest macros should
+    // reference the top macro frame.
+    const isTopLevelMacro = !(currFrame.parent?.get('isMacro'));
+    currFrame.set('isMacro', true);
+
+    this._emitLine(`function ${funcId}(${funcArgs.join(', ')}) {`);
+    this._emitLine('const callerFrame = frame;');
+
+    if (keepFrame) {
+      this._emitLine(`frame = ${isTopLevelMacro ? 'frame.push(true);' : 'topFrame.push(true);'}`);
+    } else {
+      this._emitLine('frame = new runtime.Frame();');
+      if (isTopLevelMacro) this._emitLine('const topFrame = frame;');
+    }
+
     this._emitLines(
-      'const callerFrame = frame;',
-      'frame = ' + ((keepFrame) ? 'frame.push(true);' : 'new runtime.Frame();'),
       'const kwArgs = arguments[arguments.length - 1];',
       'if (runtime.isKeywordArgs(kwArgs)) {'
     );
@@ -1138,7 +1150,11 @@ class Compiler {
       this.compile(node.body, currFrame);
     });
 
-    this._emitLine('frame = ' + ((keepFrame) ? 'frame.pop();' : 'callerFrame;'));
+    if (isTopLevelMacro) {
+      this._emitLine('frame = ' + ((keepFrame) ? 'frame.pop();' : 'callerFrame;'));
+    } else {
+      this._emitLine('frame = ' + ((keepFrame) ? 'topFrame.pop();' : 'callerFrame;'));
+    }
     this._emitLine(`return new runtime.SafeString(${bufferId});`);
     this._emitLine('}');
     this._popBuffer();

--- a/tests/compiler.test.js
+++ b/tests/compiler.test.js
@@ -1012,6 +1012,25 @@ describe('compiler', () => {
     finish(done);
   });
 
+  it('should compile macros which do not overwrite the frame of a calling macro', (t, done) => {
+    // See: https://github.com/mozilla/nunjucks/issues/1469
+    equal(
+      '{% macro page() %}' +
+      '<section class="page">' +
+      '{{ caller() | safe }}' +
+      '</section>' +
+      '{% endmacro %}' +
+      '{% macro test_page() %}' +
+      '{% set page_content = "foobar" %}' +
+      '{% call page() -%}' +
+      '{{ page_content | safe }}' +
+      '{%- endcall %}' +
+      '{% endmacro %}' +
+      '{{ test_page() | safe }}',
+      '<section class="page">foobar</section>');
+    finish(done);
+  });
+
   it('should compile macros that include other templates', (t, done) => {
     equal(
       '{% macro foo() %}{% include "include.njk" %}{% endmacro %}' +

--- a/tests/compiler.test.js
+++ b/tests/compiler.test.js
@@ -288,6 +288,16 @@ describe('compiler', () => {
         food: 'beer'
       }, 'beer');
 
+    // Return `undefined` if expression is `false`
+    equal('{% set var = "good" if hungry %}{{ "undefined" if var is undefined }}',
+      {
+        hungry: false
+      }, 'undefined');
+    equal('{{ { missing: "good" if hungry, pizza: "pepperoni" } | dump | safe }}',
+      {
+        hungry: false
+      }, '{"pizza":"pepperoni"}');
+
     finish(done);
   });
 


### PR DESCRIPTION
## Summary

Proposed change:

result of inline if with no else should be `undefined` when falsy in order to be compatible with [Jinja](https://jinja.palletsprojects.com/en/stable/templates/#if-expression).

Closes https://github.com/mozilla/nunjucks/issues/1509.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
