### PR TITLE
fix: ensure macro call doesn't overwrite frame of macro caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 * `in` operator should return `false` rather than throw on `undefined` values, consistent with Jinja. [#22](https://github.com/gunjam/govjucks/pull/22) @gunjam
 * Inline `if` with no `else` should return `undefined` when the expression is falsy, matching the [Jinja if behavior](https://jinja.palletsprojects.com/en/stable/templates/#if-expression). [#19](https://github.com/gunjam/govjucks/pull/19) @gunjam
+* Macro can overwrite the caller function body in another macro. [#20](https://github.com/gunjam/govjucks/pull/20) @gunjam
 
 ## v0.2.0
 


### PR DESCRIPTION
## Summary

Proposed change:

Macro can overwrite the caller function body in another macro. Fixed.

Closes https://github.com/mozilla/nunjucks/issues/1469


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
