### PR TITLE
feat: add alias of count for length filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Adding tojson filter based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.tojson). [#15](https://github.com/gunjam/govjucks/pull/15) @gunjam
 * Added unique filter based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-filters.tojson). [#16](https://github.com/gunjam/govjucks/pull/16) @gunjam
 * Added lipsum global function based on the [Jinja implementation](https://jinja.palletsprojects.com/en/stable/templates/#jinja-globals.lipsum). [#18](https://github.com/gunjam/govjucks/pull/18) @gunjam
+* Add alias of `count` to `length` filter. [#21](https://github.com/gunjam/govjucks/pull/21) @gunjam
 
 ## v0.1.0 (First release)
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1436,6 +1436,8 @@ c
 
 Return the length of an array or string, or the number of keys in an object:
 
+Aliases: `count`.
+
 **Input**
 
 ```jinja

--- a/src/filters.js
+++ b/src/filters.js
@@ -329,7 +329,7 @@ function lengthFilter (val) {
 }
 
 module.exports.length = lengthFilter;
-
+module.exports.count = lengthFilter;
 /**
  * Convert the value into a list.
  * If it was a string the returned list will be a list of characters.

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -614,6 +614,11 @@ describe('filter', () => {
         equal('{{ set | length }}', { set }, '2');
       }
     });
+    it('should have alias of count', () => {
+      equal('{{ str | count }}', {
+        str: 'blah'
+      }, '4');
+    });
   });
 
   it('list', (t, done) => {


### PR DESCRIPTION
## Summary

Proposed change:

Add alias of count for length filter.

Closes https://github.com/mozilla/nunjucks/issues/1304


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
