### PR TITLE
Inoperator additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Consistently support dot paths in attribute arguments for all filters. [#26](https://github.com/gunjam/govjucks/pull/26) @gunjam
 * Add support for trailing commas in array and object literals. [#25](https://github.com/gunjam/govjucks/pull/25) @gunjam
+* Add support for Map and Set to `in` operator. [#22](https://github.com/gunjam/govjucks/pull/22) @gunjam
+
+### Fixes
+* `in` operator should return `false` rather than throw on `undefined` values, consistent with Jinja. [#22](https://github.com/gunjam/govjucks/pull/22) @gunjam
 
 ## v0.2.0
 

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -229,6 +229,20 @@ You can specify multiple conditions with `and` and `or`:
 {% endif %}
 ```
 
+You can check for the existance of a property or value in an object, array,
+Map, Set or string with the `in` operator:
+
+```jinja
+{% set fridge = ["milk", "eggs", "pizza"] %}
+{% if "pizza" in fridge %}
+  I am happy.
+{% endif %}
+
+{% if "zz" in "pizza" %}
+  I am sleepy.
+{% endif %}
+```
+
 You can also use if as an [inline expression](#if-expression).
 
 ### for

--- a/src/lib.js
+++ b/src/lib.js
@@ -462,6 +462,9 @@ function inOperator (key, val) {
   if (isObject(val)) {
     return key in val;
   }
+  if (val instanceof Map || val instanceof Set) {
+    return val.has(key);
+  }
   if (val === undefined) {
     return false;
   }

--- a/src/lib.js
+++ b/src/lib.js
@@ -458,8 +458,12 @@ module.exports._assign = module.exports.extend = extend;
 function inOperator (key, val) {
   if (Array.isArray(val) || isString(val)) {
     return val.indexOf(key) !== -1;
-  } else if (isObject(val)) {
+  }
+  if (isObject(val)) {
     return key in val;
+  }
+  if (val === undefined) {
+    return false;
   }
   throw new Error('Cannot use "in" operator to search for "' +
     key + '" in unexpected types.');

--- a/tests/compiler.test.js
+++ b/tests/compiler.test.js
@@ -727,6 +727,26 @@ describe('compiler', () => {
       'yes');
   });
 
+  it('should compile the "in" operator for Maps', function () {
+    equal('{% if 1 in map %}yes{% endif %}', { map: new Map([[1, 2]]) }, 'yes');
+    equal('{% if 1 in map %}yes{% endif %}', { map: new Map([[2, 3]]) }, '');
+    equal('{% if 1 not in map %}yes{% endif %}', { map: new Map([[1, 2]]) }, '');
+    equal('{% if 1 not in map %}yes{% endif %}', { map: new Map([[2, 3]]) }, 'yes');
+    equal('{% if "a" in vals %}yes{% endif %}',
+      { vals: new Map([['a', 'b']]) },
+      'yes');
+  });
+
+  it('should compile the "in" operator for Sets', function () {
+    equal('{% if 1 in set %}yes{% endif %}', { set: new Set([1, 2]) }, 'yes');
+    equal('{% if 1 in set %}yes{% endif %}', { set: new Set([2, 3]) }, '');
+    equal('{% if 1 not in set %}yes{% endif %}', { set: new Set([1, 2]) }, '');
+    equal('{% if 1 not in set %}yes{% endif %}', { set: new Set([2, 3]) }, 'yes');
+    equal('{% if "a" in vals %}yes{% endif %}',
+      { vals: new Set(['a', 'b']) },
+      'yes');
+  });
+
   it('should compile the "in" operator for objects', function () {
     equal('{% if "a" in obj %}yes{% endif %}',
       { obj: { a: true } },
@@ -761,7 +781,21 @@ describe('compiler', () => {
     );
 
     render(
-      '{% if "a" in obj %}yes{% endif %}',
+      '{% if "a" in false %}yes{% endif %}',
+      {},
+      {
+        noThrow: true
+      },
+      function (err, res) {
+        assert.equal(res, undefined);
+        assert.match(err.message,
+          /Cannot use "in" operator to search for "a" in unexpected types\./
+        );
+      }
+    );
+
+    render(
+      '{% if "a" in null %}yes{% endif %}',
       {},
       {
         noThrow: true

--- a/tests/compiler.test.js
+++ b/tests/compiler.test.js
@@ -260,6 +260,7 @@ describe('compiler', () => {
     equal(tmpl, {
       hungry: false
     }, 'Give me some water');
+    equal(tmpl, {}, 'Give me some water');
     equal('{{ "good" if not hungry }}',
       {
         hungry: false
@@ -737,6 +738,11 @@ describe('compiler', () => {
 
   it('should compile the "in" operator for strings', function () {
     equal('{% if "foo" in "foobar" %}yes{% endif %}', 'yes');
+  });
+
+  it('should compile the "in" operator for undefined', function () {
+    equal('{% if "foo" in missing %}yes{% else %}no{% endif %}', 'no');
+    equal('{% if "foo" not in missing %}yes{% endif %}', 'yes');
   });
 
   it('should throw an error when using the "in" operator on unexpected types', (t, done) => {


### PR DESCRIPTION
## Summary

Proposed change:

* Fix nunjucks throwing when using `in` operator on undefined values, it should return `false` like jinja.
* Add support for Maps and Sets to `in` operator.
* Add `in` docs.


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
