### PR TITLE
feat: support trailing commas in array and object literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Consistently support dot paths in attribute arguments for all filters. [#26](https://github.com/gunjam/govjucks/pull/26) @gunjam
+* Add support for trailing commas in array and object literals. [#25](https://github.com/gunjam/govjucks/pull/25) @gunjam
 
 ## v0.2.0
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -1175,7 +1175,20 @@ class Parser extends Obj {
         }
       }
 
+      if (node instanceof nodes.Array &&
+        type === lexer.TOKEN_COMMA &&
+        this.skip(lexer.TOKEN_RIGHT_BRACKET)) {
+        // If the next token is a `]` we're on a trailing comma so end.
+        break;
+      }
+
       if (node instanceof nodes.Dict) {
+        // If the next token is a `}` we're on a trailing comma so we don't need
+        // to look for the next key, just end.
+        if (type === lexer.TOKEN_COMMA && this.skip(lexer.TOKEN_RIGHT_CURLY)) {
+          break;
+        }
+
         // TODO: check for errors
         const key = this.parsePrimary();
 

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -163,6 +163,15 @@ describe('parser', function () {
             [nodes.Literal, 2],
             [nodes.Literal, 3]]]]);
 
+    // Trailing comma
+    isAST(parser.parse('{{ [1,2,3,] }}'),
+      [nodes.Root,
+        [nodes.Output,
+          [nodes.Array,
+            [nodes.Literal, 1],
+            [nodes.Literal, 2],
+            [nodes.Literal, 3]]]]);
+
     isAST(parser.parse('{{ (1,2,3) }}'),
       [nodes.Root,
         [nodes.Output,
@@ -172,6 +181,18 @@ describe('parser', function () {
             [nodes.Literal, 3]]]]);
 
     isAST(parser.parse('{{ {foo: 1, \'two\': 2} }}'),
+      [nodes.Root,
+        [nodes.Output,
+          [nodes.Dict,
+            [nodes.Pair,
+              [nodes.Symbol, 'foo'],
+              [nodes.Literal, 1]],
+            [nodes.Pair,
+              [nodes.Literal, 'two'],
+              [nodes.Literal, 2]]]]]);
+
+    // Trailing comma
+    isAST(parser.parse('{{ {foo: 1, \'two\': 2,} }}'),
       [nodes.Root,
         [nodes.Output,
           [nodes.Dict,


### PR DESCRIPTION
## Summary

Proposed change:

Allow trailing commas in object array literals.

Closes https://github.com/mozilla/nunjucks/issues/1001


## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [ ] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
