### PR TITLE
feat: support dot paths in filter attribute args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+* Consistently support dot paths in attribute arguments for all filters. [#26](https://github.com/gunjam/govjucks/pull/26) @gunjam
+
 ## v0.2.0
 
 This release adds new filters and tests to close the feature parity gap between govjucks and Jina.

--- a/docs/templating.md
+++ b/docs/templating.md
@@ -1404,7 +1404,8 @@ be defined with an optional parameter:
 foo,bar,bear
 ```
 
-This  behaviour is applicable to arrays:
+You can join the common properties in an array of objects using the `attribute`
+parameter (dot paths are supported):
 
 **Input**
 
@@ -1519,13 +1520,14 @@ abc
 LO_VE_
 ```
 
-Or, given a list of objects, return a list of attribute values:
+Or, given a list of objects, return a list of attribute values (dot paths are
+supported):
 
 **Input**
 
 ```jinja
 {{ [{msg: "Hello"}, {msg: "World"}] | map(attribute="msg") | join(" ") }}
-{{ [{msg: "Hello"}, {}] | map(attribute="msg", default="missing") | join(" ") }}
+{{ [{msg: {body: "Hello"}}, {}] | map(attribute="msg.body", default="missing") | join(" ") }}
 ```
 
 **Output**
@@ -1544,6 +1546,8 @@ case-sensitive by setting `case_sensitive` as `true`.
 
 `max` can also be used on lists of objects by specifying a property to compare
 with the `attribute` parameter.
+
+Dot paths are supported.
 
 **Input**
 
@@ -1654,6 +1658,8 @@ of each object, and rejecting the objects with the test succeeding.
 This is the opposite of ```selectattr``` filter.
 
 If no test is specified, the attribute’s value will be evaluated as a boolean.
+
+Dot paths are supported.
 
 **Input**
 
@@ -1882,6 +1888,8 @@ This is the opposite to ```rejectattr```.
 
 If no test is specified, the attribute’s value will be evaluated as a boolean.
 
+Dot paths are supported.
+
 **Input**
 
 ```jinja
@@ -1991,6 +1999,22 @@ Output the sum of items in the array:
 
 ```jinja
 6
+```
+
+You can sum the values of object properties using the `attribute` parameter
+(dot paths are supported):
+
+**Input**
+
+```jinja
+{% set items = [{ price: 10 }, { num: 20 }, { num: 30 }] %}
+{{ items | sum("price") }}
+```
+
+**Output**
+
+```jinja
+60
 ```
 
 ### title
@@ -2113,6 +2137,8 @@ insensitive by default so "A" is equivalent to "a". You can enable case
 sensitivity by passing `true` as the first parameter.
 
 You can filter an array of objects using the `attribute` parameter.
+
+Dot paths are supported.
 
 **Input**
 

--- a/src/filters.js
+++ b/src/filters.js
@@ -284,9 +284,18 @@ module.exports.indent = indent;
 function join (arr, del, attr) {
   del = del || '';
 
-  let str = attr ? arr[0][attr] : arr[0];
+  if (attr) {
+    const getter = lib.getAttrGetter(attr);
+    let str = getter(arr[0]);
+    for (let i = 1, len = arr.length; i !== len; ++i) {
+      str += `${del}${getter(arr[i])}`;
+    }
+    return str;
+  }
+
+  let str = arr[0];
   for (let i = 1, len = arr.length; i !== len; ++i) {
-    str += `${del}${attr ? arr[i][attr] : arr[i]}`;
+    str += `${del}${arr[i]}`;
   }
   return str;
 }
@@ -449,12 +458,14 @@ module.exports.reject = getSelectOrReject(false);
  * @returns {Array<object>}
  */
 module.exports.rejectattr = function rejectattr (arr, attr, testName, secondArg) {
+  const getter = lib.getAttrGetter(attr);
+
   if (!testName) {
-    return arr.filter((v) => !v[attr]);
+    return arr.filter((item) => !getter(item));
   }
 
   const test = this.env.getTest(testName).bind(this);
-  return arr.filter((item) => !test(item[attr], secondArg));
+  return arr.filter((item) => !test(getter(item), secondArg));
 };
 
 module.exports.select = getSelectOrReject(true);
@@ -474,12 +485,14 @@ module.exports.select = getSelectOrReject(true);
  * @returns {Array<object>}
  */
 module.exports.selectattr = function selectattr (arr, attr, testName, secondArg) {
+  const getter = lib.getAttrGetter(attr);
+
   if (!testName) {
-    return arr.filter((v) => v[attr]);
+    return arr.filter(getter);
   }
 
   const test = this.env.getTest(testName).bind(this);
-  return arr.filter((item) => test(item[attr], secondArg));
+  return arr.filter((item) => test(getter(item), secondArg));
 };
 
 /**
@@ -663,8 +676,9 @@ module.exports.slice = slice;
 function sum (arr, attr, start) {
   let sum = start ?? 0;
   if (attr) {
+    const getter = lib.getAttrGetter(attr);
     for (let i = 0, len = arr.length; i !== len; ++i) {
-      sum += arr[i][attr];
+      sum += getter(arr[i]);
     }
     return sum;
   }
@@ -1015,8 +1029,11 @@ module.exports.map = function map (...args) {
     if (!attribute) {
       throw new lib.TemplateError('missing "attribute" keyword argument');
     }
+
+    const getter = lib.getAttrGetter(attribute);
+
     for (let i = 0; i < len; i++) {
-      arr[i] = value[i]?.[attribute] ?? defaultValue;
+      arr[i] = getter(value[i]) ?? defaultValue;
     }
     return arr;
   }
@@ -1120,15 +1137,16 @@ function minMax (check) {
    */
   function find (array, caseSensitive, attribute) {
     caseSensitive ??= false;
+    const getter = attribute && lib.getAttrGetter(attribute);
 
     let min = array[0];
-    let minCompare = attribute ? min?.[attribute] : min;
+    let minCompare = attribute ? getter(min) : min;
     minCompare = !caseSensitive && typeof minCompare === 'string'
       ? minCompare.toLowerCase()
       : minCompare;
 
     for (let i = 1, len = array.length; i < len; i++) {
-      let vc = attribute ? array[i]?.[attribute] : array[i];
+      let vc = attribute ? getter(array[i]) : array[i];
       if (caseSensitive) {
         if ((vc < minCompare) === check) {
           min = array[i];
@@ -1216,11 +1234,12 @@ const unique = r.makeMacro(
       return [...set];
     }
 
+    const getter = attribute && lib.getAttrGetter(attribute);
     const set = new Set();
     const arr = [];
 
     for (let i = 0, len = array.length; i < len; i++) {
-      const val = attribute ? array[i][attribute] : array[i];
+      const val = attribute ? getter(array[i]) : array[i];
       const key = !caseSensitive && typeof val === 'string' ? val.toLowerCase() : val;
       if (!set.has(key)) {
         arr.push(array[i]);

--- a/src/lib.js
+++ b/src/lib.js
@@ -248,42 +248,26 @@ function isObject (obj) {
 module.exports.isObject = isObject;
 
 /**
- * @param {string|number} attr
- * @returns {(string|number)[]}
- * @private
- */
-function _prepareAttributeParts (attr) {
-  if (!attr) {
-    return [];
-  }
-
-  if (typeof attr === 'string') {
-    return attr.split('.');
-  }
-
-  return [attr];
-}
-
-/**
  * @param {string}   attribute      Attribute value. Dots allowed.
  * @returns {function(Object): *}
  */
 function getAttrGetter (attribute) {
-  const parts = _prepareAttributeParts(attribute);
+  if (typeof attribute !== 'string' || attribute.indexOf('.') === -1) {
+    return (obj) => obj[attribute];
+  }
+
+  const parts = attribute.split('.');
 
   return function attrGetter (item) {
-    let _item = item;
-
     for (let i = 0, len = parts.length; i < len; i++) {
       // If item is not an object, and we still got parts to handle, it means
       // that something goes wrong. Just roll out to undefined in that case.
-      _item = _item?.[parts[i]];
-      if (_item === undefined) {
-        return _item;
+      item = item?.[parts[i]];
+      if (item === undefined) {
+        return item;
       }
     }
-
-    return _item;
+    return item;
   };
 }
 

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -512,6 +512,26 @@ describe('filter', () => {
         }]
       },
       'foo,bar,bear');
+
+    equal('{{ items | join(",", "name.first") }}',
+      {
+        items: [{
+          name: {
+            first: 'foo'
+          }
+        },
+        {
+          name: {
+            first: 'bar'
+          }
+        },
+        {
+          name: {
+            first: 'bear'
+          }
+        }]
+      },
+      'foo,bar,bear');
     finish(done);
   });
 
@@ -687,6 +707,14 @@ describe('filter', () => {
         ]
       }, 'John, Jim, Anonymous');
 
+      equal('{{ users | map(attribute="user.name", default="Anonymous") | join(", ") }}', {
+        users: [
+          { user: { name: 'John' } },
+          { user: { name: 'Jim' } },
+          {},
+        ]
+      }, 'John, Jim, Anonymous');
+
       assert.throws(() => render('{{ users | map(default="Anonymous") | join(", ") }}', {
         users: [
           { username: 'John' },
@@ -753,6 +781,15 @@ describe('filter', () => {
         { prop: 'AB' }
       ]
     }, '{"prop":"BB"}');
+    equal('{{ data | max(attribute="nested.prop") | dump | safe }}', {
+      data: [
+        { nested: { prop: 'AC' } },
+        { nested: { prop: 'aa' } },
+        { nested: { prop: 'BB' } },
+        { nested: { prop: 'ba' } },
+        { nested: { prop: 'AB' } }
+      ]
+    }, '{"nested":{"prop":"BB"}}');
 
     finish(done);
   });
@@ -809,6 +846,16 @@ describe('filter', () => {
         { prop: 'AB' }
       ]
     }, '{"prop":"aa"}');
+
+    equal('{{ data | min(attribute="nested.prop") | dump | safe }}', {
+      data: [
+        { nested: { prop: 'AC' } },
+        { nested: { prop: 'aa' } },
+        { nested: { prop: 'BB' } },
+        { nested: { prop: 'ba' } },
+        { nested: { prop: 'AB' } }
+      ]
+    }, '{"nested":{"prop":"aa"}}');
 
     finish(done);
   });
@@ -882,6 +929,17 @@ describe('filter', () => {
       people
     }, '1');
 
+    const people2 = [{
+      stats: { age: 30 }
+    }, {
+      stats: { age: 21 }
+    }, {
+      stats: { age: 23 }
+    }];
+    equal('{{ people | rejectattr("stats.age", "odd") | dump | safe }}', {
+      people: people2
+    }, '[{"stats":{"age":30}}]');
+
     finish(done);
   });
 
@@ -923,6 +981,17 @@ describe('filter', () => {
     equal('{{ people | selectattr("age", "odd") | length }}', {
       people
     }, '2');
+
+    const people2 = [{
+      stats: { age: 30 }
+    }, {
+      stats: { age: 21 }
+    }, {
+      stats: { age: 23 }
+    }];
+    equal('{{ people | selectattr("stats.age", "odd") | dump | safe }}', {
+      people: people2
+    }, '[{"stats":{"age":21}},{"stats":{"age":23}}]');
 
     finish(done);
   });
@@ -1043,6 +1112,16 @@ describe('filter', () => {
           { value: 1 },
           { value: 2 },
           { value: 3 }
+        ]
+      },
+      '16');
+
+    equal('{{ items | sum("value.num", 10) }}',
+      {
+        items: [
+          { value: { num: 1 } },
+          { value: { num: 2 } },
+          { value: { num: 3 } }
         ]
       },
       '16');
@@ -1236,6 +1315,15 @@ describe('filter', () => {
         { value: 2 }
       ]
     }, '[{"value":3},{"value":2},{"value":4},{"value":1}]');
+    equal('{{ items|unique(attribute="nested.value")|dump|safe }}', {
+      items: [
+        { nested: { value: 3 } },
+        { nested: { value: 2 } },
+        { nested: { value: 4 } },
+        { nested: { value: 1 } },
+        { nested: { value: 2 } }
+      ]
+    }, '[{"nested":{"value":3}},{"nested":{"value":2}},{"nested":{"value":4}},{"nested":{"value":1}}]');
     equal('{{ items|unique(case_sensitive=true, attribute="value")|dump|safe }}', {
       items: [
         { value: 'c' },


### PR DESCRIPTION
## Summary

Proposed change:

Consistently  support dot paths in attribute arguments for all filters.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [x] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
