### PR TITLE
refactor: replace peer dependency chokidar with node:fs watch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ['>=20.19.0', 22, 24]
+        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: [22, 24]
+        os: [ubuntu-latest, macos-latest]
+        node-version: [22, 24, 26]
+        include:
+        - os: windows-latest
+          node_version: 22
+        - os: windows-latest
+          # use 24.15 to workaround https://github.com/nodejs/node/issues/63638
+          node_version: 24.15.0
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/api.md
+++ b/docs/api.md
@@ -478,7 +478,10 @@ templates from the filesystem using node's
 [`require.resolve`](https://nodejs.org/api/modules.html#modules_all_together).
 
 **opts** is an object which takes the same properties as
-[`FileSystemLoader`](#filesystemloader).
+[`FileSystemLoader`](#filesystemloader). Plus one additional option:
+
+* **requirePaths** - an array of string paths to search for node_modules folders,
+  equivalent to [`require.resolve`'s paths option](https://nodejs.org/api/modules.html#requireresolverequest-options).
 
 ### WebLoader
 ```js

--- a/package.json
+++ b/package.json
@@ -18,14 +18,6 @@
     "neostandard": "^0.12.2",
     "nunjucks": "^3.2.4"
   },
-  "peerDependencies": {
-    "chokidar": "^3.3.0"
-  },
-  "peerDependenciesMeta": {
-    "chokidar": {
-      "optional": true
-    }
-  },
   "engines": {
     "node": ">=20.19.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   },
   "type": "commonjs",
   "devDependencies": {
-    "c8": "^11.0.0",
+    "c8": "^12.0.0",
     "connect": "^3.7.0",
     "eslint": "^9.39.3",
     "express": "5.x",
     "light-my-request": "^6.6.0",
     "mitata": "^1.0.34",
-    "neostandard": "^0.12.2",
+    "neostandard": "^0.13.0",
     "nunjucks": "^3.2.4"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "nunjucks": "^3.2.4"
   },
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22"
   },
   "scripts": {
     "codecov": "codecov",

--- a/src/node-loaders.js
+++ b/src/node-loaders.js
@@ -4,22 +4,39 @@ const fs = require('node:fs');
 const path = require('node:path');
 const Loader = require('./loader');
 const { PrecompiledLoader } = require('./precompiled-loader.js');
-let chokidar;
+
+/**
+ * @param {FileSystemLoader | NodeResolveLoader} instance
+ * @param {string} watchPath
+ * @returns {fs.WatchListener<string>}
+ */
+function getWatchHandler (instance, watchPath) {
+  return (_, filename) => {
+    if (filename) {
+      const fullname = path.resolve(watchPath, filename);
+      if (fullname in instance.pathsToNames) {
+        instance.emit('update', instance.pathsToNames[fullname], fullname);
+      }
+    }
+  };
+}
 
 /**
  * Load templates from the filesystem, using the searchPaths array as paths to
  * look for templates.
  */
 class FileSystemLoader extends Loader {
+  /** @type {fs.FSWatcher[] | undefined} */
+  #watchers;
+
   /**
    * @param {string | string[]} [searchPaths] File paths to look for govjucks
    *   templates
    * @param {FileSystemLoaderOptions} [opts] Options
    */
-  constructor (searchPaths, opts) {
+  constructor (searchPaths, opts = {}) {
     super();
 
-    opts = opts ?? {};
     this.pathsToNames = {};
     this.noCache = !!opts.noCache;
 
@@ -32,24 +49,28 @@ class FileSystemLoader extends Loader {
     }
 
     if (opts.watch) {
+      this.#watchers = [];
+
       // Watch all the templates in the paths and fire an event when
       // they change
-      try {
-        chokidar = require('chokidar');
-      } catch (cause) {
-        throw new Error('watch requires chokidar to be installed', { cause });
+      for (const searchPath of this.searchPaths.filter(fs.existsSync)) {
+        const watcher = fs.watch(searchPath, { recursive: true });
+        watcher.on('change', getWatchHandler(this, searchPath));
+        watcher.on('error', (error) => {
+          console.log('Watcher error: ' + error);
+        });
+        this.#watchers.push(watcher);
       }
-      const paths = this.searchPaths.filter(fs.existsSync);
-      const watcher = chokidar.watch(paths);
-      watcher.on('all', (event, fullname) => {
-        fullname = path.resolve(fullname);
-        if (event === 'change' && fullname in this.pathsToNames) {
-          this.emit('update', this.pathsToNames[fullname], fullname);
-        }
-      });
-      watcher.on('error', (error) => {
-        console.log('Watcher error: ' + error);
-      });
+    }
+  }
+
+  /**
+   * When in watch mode, stop watching the templates for changes. Once stopped,
+   * the watchers can not be restarted.
+   */
+  stopWatching () {
+    for (const watcher of this.#watchers) {
+      watcher.close();
     }
   }
 
@@ -94,33 +115,64 @@ class FileSystemLoader extends Loader {
  * Loads templates from the filesystem using node's require.resolve
  */
 class NodeResolveLoader extends Loader {
+  /** @type {fs.FSWatcher[] | undefined} */
+  #watchers;
+  /** @type {Set<string> | undefined} */
+  #watchPaths;
+  /** @type {String[] | undefined} */
+  #requirePaths;
+  #watching = false;
+
   /**
    * @param {FileSystemLoaderOptions} opts Options
    */
-  constructor (opts) {
+  constructor (opts = {}) {
     super();
-    opts = opts || {};
+
     this.pathsToNames = {};
     this.noCache = !!opts.noCache;
+    this.#requirePaths = Array.isArray(opts.requirePaths)
+      ? opts.requirePaths
+      : undefined;
 
     if (opts.watch) {
-      try {
-        chokidar = require('chokidar');
-      } catch (cause) {
-        throw new Error('watch requires chokidar to be installed', { cause });
+      this.#watching = true;
+      this.#watchers = [];
+      this.#watchPaths = new Set();
+      this.on('load', (_, source) => {
+        const dir = path.dirname(source.path);
+
+        // Don't watch the same path twice or any parent paths
+        if (
+          this.#watching === false ||
+          this.#watchPaths.has(dir) ||
+          Array.from(this.#watchPaths).some((p) => dir.startsWith(p))
+        ) {
+          return;
+        }
+
+        this.#watchPaths.add(dir);
+
+        const watcher = fs.watch(dir, { recursive: true });
+        watcher.on('change', getWatchHandler(this, dir));
+        watcher.on('error', (error) => {
+          console.log('Watcher error: ' + error);
+        });
+        this.#watchers.push(watcher);
+      });
+    }
+  }
+
+  /**
+   * When in watch mode, stop watching the templates for changes. Once stopped,
+   * the watchers can not be restarted.
+   */
+  stopWatching () {
+    if (this.#watching) {
+      for (const watcher of this.#watchers) {
+        watcher.close();
       }
-      this.watcher = chokidar.watch();
-
-      this.watcher.on('change', (fullname) => {
-        this.emit('update', this.pathsToNames[fullname], fullname);
-      });
-      this.watcher.on('error', (error) => {
-        console.log('Watcher error: ' + error);
-      });
-
-      this.on('load', (name, source) => {
-        this.watcher.add(source.path);
-      });
+      this.#watching = false;
     }
   }
 
@@ -141,7 +193,11 @@ class NodeResolveLoader extends Loader {
     let fullpath;
 
     try {
-      fullpath = require.resolve(name);
+      const opts = this.#requirePaths
+        ? { paths: this.#requirePaths }
+        : undefined;
+
+      fullpath = require.resolve(name, opts);
     } catch {
       return null;
     }

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -1,11 +1,22 @@
 'use strict';
 
 const assert = require('node:assert/strict');
-const { describe, it } = require('node:test');
+const { mkdtempSync, cpSync, rmSync, writeFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const { before, after, describe, it } = require('node:test');
+const path = require('node:path');
 const { Environment } = require('../src/environment');
 const { FileSystemLoader, NodeResolveLoader } = require('../src/node-loaders');
 
 const templatesPath = 'tests/templates';
+const tmpDir = tmpdir();
+let tmp;
+
+before(() => {
+  tmp = mkdtempSync(path.join(tmpDir, 'loaders-'));
+});
+
+after(() => rmSync(tmp, { recursive: true }));
 
 describe('loader', () => {
   it('should allow a simple loader to be created', () => {
@@ -61,10 +72,50 @@ describe('loader', () => {
       const loader = new FileSystemLoader(templatesPath);
       loader.on('load', function (name, source) {
         assert.equal(name, 'simple-base.njk');
+        assert.deepEqual(source, {
+          src: '{% block test %}{% endblock test %}\n',
+          path: path.resolve(templatesPath, 'simple-base.njk'),
+          noCache: false
+        });
         done();
       });
 
       loader.getSource('simple-base.njk');
+    });
+
+    it('should emit an "update" event on file change in watch mode', (t, done) => {
+      const templatePath = path.join(tmp, 'fs-update.njk');
+      writeFileSync(templatePath, 'test');
+
+      const loader = new FileSystemLoader(tmp, { watch: true });
+      loader.on('update', function (path, fullPath) {
+        assert.equal(path, 'fs-update.njk');
+        assert.equal(fullPath, templatePath);
+        done();
+      });
+
+      // Get source so it's added to paths list
+      loader.getSource('fs-update.njk');
+
+      // Modify file
+      writeFileSync(templatePath, 'updated');
+      t.after(() => loader.stopWatching());
+    });
+
+    it('should load template from file system', (t) => {
+      const loader = new FileSystemLoader(templatesPath);
+      const source = loader.getSource('item.njk');
+      assert.deepEqual(source, {
+        src: 'showing {{ item }}',
+        path: path.resolve(templatesPath, 'item.njk'),
+        noCache: false
+      });
+    });
+
+    it('should render templates', () => {
+      const env = new Environment(new FileSystemLoader(templatesPath));
+      const tmpl = env.getTemplate('item.njk');
+      assert.equal(tmpl.render({ item: 'foo' }), 'showing foo');
     });
   });
 
@@ -79,10 +130,38 @@ describe('loader', () => {
       const loader = new NodeResolveLoader();
       loader.on('load', function (name, source) {
         assert.equal(name, 'dummy-pkg/simple-template.html');
+        assert.deepEqual(source, {
+          src: '{{ foo }}',
+          path: require.resolve('dummy-pkg/simple-template.html'),
+          noCache: false
+        });
         done();
       });
 
       loader.getSource('dummy-pkg/simple-template.html');
+    });
+
+    it('should emit an "update" event on file change in watch mode', (t, done) => {
+      const modules = path.join(tmp, 'node_modules');
+      const templatePath = path.join(modules, 'dummy-pkg', 'simple-template.html');
+      cpSync(path.join(__dirname, 'test-node-pkgs'), modules, { recursive: true });
+
+      const loader = new NodeResolveLoader({ watch: true, requirePaths: [modules] });
+      loader.on('update', function (path, fullPath) {
+        const expectedPath = require.resolve('dummy-pkg/simple-template.html', {
+          paths: [modules]
+        });
+        assert.equal(path, 'dummy-pkg/simple-template.html');
+        assert.equal(fullPath, expectedPath);
+        done();
+      });
+
+      // Get source so it's added to paths list
+      loader.getSource('dummy-pkg/simple-template.html');
+
+      // Modify file
+      writeFileSync(templatePath, 'updated');
+      t.after(() => loader.stopWatching());
     });
 
     it('should render templates', () => {


### PR DESCRIPTION
## Summary

Proposed change:

Remove chokidar and replace with node ` fs.watch()`.

## Checklist

I've completed the checklist below to ensure I didn't forget anything. This makes reviewing this PR as easy as possible for the maintainers. And it gets this change released as soon as possible.

* [x] Proposed change helps towards [*purpose of this project*](https://github.com/gunjam/govjucks/blob/master/CONTRIBUTING.md#purpose).
* [x] [*Documentation*](https://github.com/gunjam/govjucks/tree/master/docs/) is added / updated to describe proposed change.
* [x] [*Tests*](https://github.com/gunjam/govjucks/tree/master/tests) are added / updated to cover proposed change.
* [ ] [*Changelog*](https://github.com/gunjam/govjucks/blob/master/CHANGELOG.md) has an entry for proposed change (if user-facing fix or feature).

<!-- Tick of items by replacing `[ ]` by `[x]` -->
