### PR TITLE
test: timeout test run afer 2 mins

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "codecov": "codecov",
     "lint": "eslint src tests",
-    "test:unit": "node --env-file=.test.env --test",
+    "test:unit": "node --env-file=.test.env --test-timeout=120000 --test",
     "test:coverage": "c8 npm run test:unit",
     "test": "npm run lint && npm run test:coverage"
   },


### PR DESCRIPTION
Loader tests on macos are flakey and can not complete, so add timeout for test run